### PR TITLE
Ignore src port when detecting auth header reuse

### DIFF
--- a/sql/sample-data/traffic.sql
+++ b/sql/sample-data/traffic.sql
@@ -22,7 +22,7 @@ INSERT INTO traffic (occurred_at, data) VALUES
 	"request": {
     "absoluteURI": "http://example.com/url-1",
 		"headers": {
-			"Authorization": "$argon2i$v=19$m=16,t=2,p=1$fGxJWjolVURhX2xbUGlWRVBtN3xGJldxW01URiMzNmg$oKXSg9IvLop//YzTkFL7Xw"
+			"Authorization": "fGxJWjolVURhX2xbUGlWRVBtN3xGJldxW01URiMzNmg$oKXSg9IvLop//YzTkFL7Xw"
 		}
 	},
   "dst": {
@@ -45,7 +45,7 @@ INSERT INTO traffic (occurred_at, data) VALUES
 	"request": {
     "absoluteURI": "http://example.com/url-2",
 		"headers": {
-			"Authorization": "$argon2i$v=19$m=16,t=2,p=1$fGxJWjolVURhX2xbUGlWRVBtN3xGJldxW01URiMzNmg$oKXSg9IvLop//YzTkFL7Xw"
+			"Authorization": "fGxJWjolVURhX2xbUGlWRVBtN3xGJldxW01URiMzNmg$oKXSg9IvLop//YzTkFL7Xw"
 		}
 	},
   "dst": {
@@ -56,7 +56,7 @@ INSERT INTO traffic (occurred_at, data) VALUES
   "src": {
     "ip": "192.2.0.1",
     "name": "",
-    "port": "57944"
+    "port": "57945"
   },
 	"id": "000000000000000000000091",
 	"timestamp": 1674047521000
@@ -69,7 +69,7 @@ INSERT INTO traffic (occurred_at, data) VALUES
 	"request": {
     "absoluteURI": "http://example.com/url-1",
 		"headers": {
-			"Authorization": "$argon2i$v=19$m=16,t=2,p=1$fGxJWjolVURhX2xbUGlWRVBtN3xGJldxW01URiMzNmg$oKXSg9IvLop//YzTkFL7Xw"
+			"Authorization": "fGxJWjolVURhX2xbUGlWRVBtN3xGJldxW01URiMzNmg$oKXSg9IvLop//YzTkFL7Xw"
 		}
 	},
   "dst": {
@@ -93,7 +93,7 @@ INSERT INTO traffic (occurred_at, data) VALUES
 	"request": {
     "absoluteURI": "http://example.com/url-1",
 		"headers": {
-			"Authorization": "$argon2i$v=19$m=16,t=2,p=1$fGxJWjolVURhX2xbUGlWRVBtN3xGJldxW01URiMzNmg$oKXSg9IvLop//xyzzy"
+			"Authorization": "fGxJWjolVURhX2xbUGlWRVBtN3xGJldxW01URiMzNmg$oKXSg9IvLop//xyzzy"
 		}
 	},
   "dst": {

--- a/ui/src/__tests__/analysis/reused-authentication.test.ts
+++ b/ui/src/__tests__/analysis/reused-authentication.test.ts
@@ -13,7 +13,7 @@ test("runner works", async () => {
         src_port: "57944",
         dst_ip: "10.1.0.96",
         dst_port: "8181",
-        URI: "http://example.com/url-2",
+        uri: "http://example.com/url-2",
         timestamp: new Date("2023-01-18T13:12:01.000Z"),
       },
       {
@@ -25,7 +25,7 @@ test("runner works", async () => {
         src_port: "57944",
         dst_ip: "10.1.0.96",
         dst_port: "8181",
-        URI: "http://example.com/url-1",
+        uri: "http://example.com/url-1",
         timestamp: new Date("2023-01-18T13:12:02.000Z"),
       },
     ]);


### PR DESCRIPTION
Client ports change with every connection

Before you submit your PR, make sure you check each of the following:

1. [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and signed the [Contributor License Agreement](./CLA.md).
2. [x] My code is clean and ready-to-PR, including being free of lint errors and dead code
3. [x] I have **tested** my change / code and am confident that it works
4. [x] I have filled in the template below completely and accurately

##### Changelog

- disregard source port when detecting authorization header reuse because the source port changes with every connection
