### PR TITLE
STR-4267: No Results card

### DIFF
--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -4,3 +4,6 @@ node_modules
 npm-debug.log
 README.md
 .git
+coverage
+.next
+.swc

--- a/ui/components/app/Analysis/ExpiredJWTCard.tsx
+++ b/ui/components/app/Analysis/ExpiredJWTCard.tsx
@@ -37,7 +37,7 @@ export const ExpiredJWTCard: React.FC<Analysis<'expired-jwt'>> = ({
   findings,
   ...otherProps
 }) => {
-  return <AnalysisCard {...otherProps}>
+  return <AnalysisCard {...otherProps} noResults={(findings ?? []).length === 0}>
     <div style={{height: '400px', width: '100%'}}>
     <DataGrid
       rows={(findings ?? []).map(({

--- a/ui/components/app/Analysis/PasswordInURLCard.tsx
+++ b/ui/components/app/Analysis/PasswordInURLCard.tsx
@@ -29,7 +29,7 @@ export const PasswordInURLCard: React.FC<Analysis<'pass-in-url'>> = ({
   findings,
   ...otherProps
 }) => {
-  return <AnalysisCard {...otherProps}>
+  return <AnalysisCard {...otherProps} noResults={(findings ?? []).length === 0}>
     <div style={{height: '400px', width: '100%'}}>
     <DataGrid
       rows={(findings ?? []).map(({

--- a/ui/components/app/Analysis/ReusedAuthentication.tsx
+++ b/ui/components/app/Analysis/ReusedAuthentication.tsx
@@ -19,7 +19,7 @@ export const ReusedAuthenticationCard: React.FC<Analysis<'reused-auth'>> = ({
   findings,
   ...otherProps
 }) => {
-  return <AnalysisCard {...otherProps}>
+  return <AnalysisCard {...otherProps} noResults={(findings ?? []).length === 0}>
     <div style={{height: '400px', width: '100%'}}>
     <DataGrid
       rows={(findings ?? []).flatMap((f) => (

--- a/ui/components/app/Analysis/UseOfBasicAuthCard.tsx
+++ b/ui/components/app/Analysis/UseOfBasicAuthCard.tsx
@@ -28,7 +28,7 @@ export const UseOfBasicAuthCard: React.FC<Analysis<'use-of-basic-auth'>> = ({
   findings,
   ...otherProps
 }) => {
-  return <AnalysisCard {...otherProps}>
+  return <AnalysisCard {...otherProps} noResults={(findings ?? []).length === 0}>
     <div style={{height: '400px', width: '100%'}}>
     <DataGrid
       rows={(findings ?? []).map(({

--- a/ui/components/app/Analysis/core/__snapshots__/index.spec.tsx.snap
+++ b/ui/components/app/Analysis/core/__snapshots__/index.spec.tsx.snap
@@ -107,7 +107,7 @@ exports[`AnalysisCard renders a weaknessLink without title 1`] = `
           </tr>
           <tr>
             <td>
-              Learn more:
+              Learn more:
             </td>
             <td>
               <a
@@ -176,7 +176,7 @@ exports[`AnalysisCard renders all passed props 1`] = `
           </tr>
           <tr>
             <td>
-              Learn more:
+              Learn more:
             </td>
             <td>
               <a

--- a/ui/components/app/Analysis/core/index.tsx
+++ b/ui/components/app/Analysis/core/index.tsx
@@ -2,15 +2,23 @@ import React from 'react';
 import {
   Card,
   CardContent,
+  useTheme,
+  Collapse,
+  CardActions,
+  styled,
+  IconButton,
 } from '@mui/material';
+import Link from 'next/link';
 
 import type { Analysis as AnalysisType } from '@/lib/findings';
-import { SeverityIcon, Typography } from '@/components/atoms';
+import { SeverityIcon, Checkmark, Typography } from '@/components/atoms';
 import { FormattedDate } from '@/components/atoms/FormattedDate';
-import Link from 'next/link';
+import { GridExpandMoreIcon } from '@mui/x-data-grid';
+import { IconButtonProps } from '@mui/material/IconButton';
 
 export type AnalysisProps = {
   children?: React.ReactNode;
+  noResults?: boolean;
 } & Pick<
   AnalysisType,
   'description'
@@ -21,6 +29,88 @@ export type AnalysisProps = {
   | 'title'
 >;
 
+interface ExpandMoreProps extends IconButtonProps {
+  expand: boolean;
+}
+
+const ExpandMore = styled((props: ExpandMoreProps) => {
+  const { expand, ...other } = props;
+  return <IconButton {...other} />;
+})(({ theme, expand }) => ({
+  transform: !expand ? 'rotate(0deg)' : 'rotate(180deg)',
+  marginLeft: 'auto',
+  transition: theme.transitions.create('transform', {
+    duration: theme.transitions.duration.shortest,
+  }),
+}));
+
+const Weakness: React.FC<{
+  weaknessLink?: string
+  weaknessTitle?: string
+}> = ({ weaknessLink, weaknessTitle }) => (
+  weaknessLink
+  ? (
+    <tr>
+      <td>Learn&nbsp;more:</td>
+      <td>
+        <Link className='underline' href={weaknessLink}>{weaknessTitle ?? weaknessLink}</Link>
+      </td>
+    </tr>
+  )
+  : null
+);
+
+const NoResults: React.FC<AnalysisProps> = ({
+  description,
+  reportedAt,
+  weaknessLink,
+  weaknessTitle,
+  title,
+}) => {
+  const theme = useTheme();
+  const [expanded, setExpanded] = React.useState(false);
+
+  const handleExpandClick = () => {
+    setExpanded(!expanded);
+  };
+
+  return <Card className='max-w-prose -my-3'>
+    <CardContent className='flex items-center'>
+      <Typography
+        variant='h2'
+        className='font-light grow align-text-bottom'
+        style={{color: theme.palette.success.main}}
+      >
+        <Checkmark/>{' '}
+        {title}
+        {' - OK'}
+      </Typography>
+      <ExpandMore
+        expand={expanded}
+        onClick={handleExpandClick}
+        aria-expanded={expanded}
+        aria-label="show description"
+      >
+        <GridExpandMoreIcon/>
+      </ExpandMore>
+    </CardContent>
+    <Collapse in={expanded} timeout="auto" unmountOnExit>
+      <CardContent sx={{paddingTop: 0}}>
+        <Typography className='max-w-prose mb-4 text-zinc-400' variant='body1'>{description}</Typography>
+        <table className='font-light text-zinc-400 border-separate border-spacing-x-4'>
+          <tbody>
+            <tr>
+              <td>Updated:</td>
+              <td><FormattedDate when={reportedAt}/></td>
+            </tr>
+            <Weakness weaknessLink={weaknessLink} weaknessTitle={weaknessTitle}/>
+          </tbody>
+        </table>
+      </CardContent>
+    </Collapse>
+  </Card>
+}
+
 export const AnalysisCard: React.FC<AnalysisProps> = ({
   description,
   reportedAt,
@@ -28,14 +118,20 @@ export const AnalysisCard: React.FC<AnalysisProps> = ({
   weaknessTitle,
   severity,
   title,
+  noResults,
   children,
-}) => {
-  let weaknessFragment = null;
-  if (weaknessLink !== undefined) {
-    weaknessFragment = <Link className='underline' href={weaknessLink}>{weaknessTitle ?? weaknessLink}</Link>;
-  }
-
-  return <Card>
+}) => (
+  noResults
+    ? <NoResults {...{
+      description,
+      reportedAt,
+      weaknessLink,
+      weaknessTitle,
+      severity,
+      title,
+      noResults,
+    }}/>
+    : <Card>
     <CardContent>
       <Typography variant='h2'><SeverityIcon severity={severity}/> {title}</Typography>
       <Typography className='max-w-prose my-2' variant='body1'>{description}</Typography>
@@ -47,12 +143,10 @@ export const AnalysisCard: React.FC<AnalysisProps> = ({
           <tr>
             <td>Issue Severity:</td><td>{severity}</td>
           </tr>
-          {weaknessFragment && <tr>
-            <td>Learn more:</td><td>{weaknessFragment}</td>
-          </tr>}
+          <Weakness weaknessLink={weaknessLink} weaknessTitle={weaknessTitle}/>
         </tbody>
       </table>
       {children}
     </CardContent>
   </Card>
-}
+)

--- a/ui/components/app/Layout/Layout.tsx
+++ b/ui/components/app/Layout/Layout.tsx
@@ -1,13 +1,17 @@
+import { CssBaseline, ThemeProvider } from '@mui/material';
 import React from 'react';
+
+import { theme } from '@/components/app/theme';
 
 export interface LayoutProps {
   children: React.ReactNode;
 }
 
 export const Layout = ({ children }: LayoutProps) => {
-  return (
+  return (<ThemeProvider theme={theme}>
+    <CssBaseline/>
     <div className="m-0 flex flex-col justify-between items-start w-screen">
       {children}
     </div>
-  );
+  </ThemeProvider>);
 };

--- a/ui/components/app/Summary/__snapshots__/Summary.spec.tsx.snap
+++ b/ui/components/app/Summary/__snapshots__/Summary.spec.tsx.snap
@@ -8,17 +8,22 @@ exports[`Analyses Summary Component renders all problems variant 1`] = `
     className="MuiCardContent-root css-46bh2p-MuiCardContent-root"
   >
     <h3
-      className="MuiTypography-root MuiTypography-h5 css-ag7rrr-MuiTypography-root"
+      className="leading-6 text-h4 font-poppins font-semibold"
     >
       Ongoing Results
     </h3>
     <p
-      className="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+      className="leading-6 text-body1 font-nunito"
     >
       7 Faults (143 Findings)
     </p>
     <p
-      className="MuiTypography-root MuiTypography-body1 css-1pnmrwp-MuiTypography-root"
+      className="leading-6 text-body1 font-nunito"
+      style={
+        {
+          "color": "rgba(0, 0, 0, 0.6)",
+        }
+      }
     >
       10
        passed
@@ -117,17 +122,22 @@ exports[`Analyses Summary Component renders no problems variant 1`] = `
     className="MuiCardContent-root css-46bh2p-MuiCardContent-root"
   >
     <h3
-      className="MuiTypography-root MuiTypography-h5 css-ag7rrr-MuiTypography-root"
+      className="leading-6 text-h4 font-poppins font-semibold"
     >
       Ongoing Results
     </h3>
     <p
-      className="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+      className="leading-6 text-body1 font-nunito"
     >
-      No problems detected
+      No problems detected yet. Live scanning will continue in the background.
     </p>
     <p
-      className="MuiTypography-root MuiTypography-body1 css-1pnmrwp-MuiTypography-root"
+      className="leading-6 text-body1 font-nunito"
+      style={
+        {
+          "color": "rgba(0, 0, 0, 0.6)",
+        }
+      }
     >
       17
        passed
@@ -145,17 +155,22 @@ exports[`Analyses Summary Component renders some problems variant 1`] = `
     className="MuiCardContent-root css-46bh2p-MuiCardContent-root"
   >
     <h3
-      className="MuiTypography-root MuiTypography-h5 css-ag7rrr-MuiTypography-root"
+      className="leading-6 text-h4 font-poppins font-semibold"
     >
       Ongoing Results
     </h3>
     <p
-      className="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+      className="leading-6 text-body1 font-nunito"
     >
       7 Faults (143 Findings)
     </p>
     <p
-      className="MuiTypography-root MuiTypography-body1 css-1pnmrwp-MuiTypography-root"
+      className="leading-6 text-body1 font-nunito"
+      style={
+        {
+          "color": "rgba(0, 0, 0, 0.6)",
+        }
+      }
     >
       10
        passed

--- a/ui/components/app/Summary/__snapshots__/Summary.spec.tsx.snap
+++ b/ui/components/app/Summary/__snapshots__/Summary.spec.tsx.snap
@@ -237,13 +237,18 @@ exports[`Analyses Summary Loading Component rednders correctly 1`] = `
     className="MuiCardContent-root css-46bh2p-MuiCardContent-root"
   >
     <h3
-      className="MuiTypography-root MuiTypography-h5 h-5 bg-gray-200 rounded-full dark:bg-gray-500 w-48 mb-2 css-ag7rrr-MuiTypography-root"
+      className="leading-6 text-h4 font-poppins font-semibold h-5 bg-gray-200 rounded-full dark:bg-gray-500 w-48 mb-2"
     />
     <p
-      className="MuiTypography-root MuiTypography-body1 h-2.5 bg-gray-200 rounded-full dark:bg-gray-500 w-40 mb-2 css-ahj2mt-MuiTypography-root"
+      className="leading-6 text-body1 font-nunito h-2.5 bg-gray-200 rounded-full dark:bg-gray-500 w-40 mb-2"
     />
     <p
-      className="MuiTypography-root MuiTypography-body1 h-2 bg-gray-200 rounded-full dark:bg-gray-500 w-20 mb-2 css-1pnmrwp-MuiTypography-root"
+      className="leading-6 text-body1 font-nunito h-2 bg-gray-200 rounded-full dark:bg-gray-500 w-20 mb-2"
+      style={
+        {
+          "color": "rgba(0, 0, 0, 0.6)",
+        }
+      }
     />
     <ul>
       <li

--- a/ui/components/app/Summary/index.tsx
+++ b/ui/components/app/Summary/index.tsx
@@ -28,13 +28,14 @@ export const Summary = ({ faults, findings, scansPassed, severityCounts }: Summa
 }
 
 export const SummaryLoading = () => {
+  const theme = useTheme();
   const liClassName = 'w-32 h-2.5 bg-gray-200 rounded-full dark:bg-gray-500 mb-2';
 
   return (<Card className="animate-pulse">
     <CardContent>
-      <Typography variant="h5" component="h3" className="h-5 bg-gray-200 rounded-full dark:bg-gray-500 w-48 mb-2"></Typography>
+      <Typography variant="h4" component="h3" className="h-5 bg-gray-200 rounded-full dark:bg-gray-500 w-48 mb-2"></Typography>
       <Typography className="h-2.5 bg-gray-200 rounded-full dark:bg-gray-500 w-40 mb-2"></Typography>
-      <Typography className="h-2 bg-gray-200 rounded-full dark:bg-gray-500 w-20 mb-2" color="text.secondary"></Typography>
+      <Typography className="h-2 bg-gray-200 rounded-full dark:bg-gray-500 w-20 mb-2" style={{color: theme.palette.text.secondary}}></Typography>
       <ul>
         <li className={liClassName} key="critical"></li>
         <li className={liClassName} key="high"></li>

--- a/ui/components/app/Summary/index.tsx
+++ b/ui/components/app/Summary/index.tsx
@@ -1,22 +1,21 @@
 import React from 'react';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
+import { Card, CardContent, useTheme } from '@mui/material';
 import { AnalysesSummary } from 'lib/findings';
-import { SeverityIcon } from '@/components/atoms';
+import { SeverityIcon, Typography } from '@/components/atoms';
 
 type SummaryProps = AnalysesSummary;
 
 export const Summary = ({ faults, findings, scansPassed, severityCounts }: SummaryProps) => {
+  const theme = useTheme();
   const summaryTitle = faults
     ? `${faults} Faults (${findings} Findings)`
-    : `No problems detected`;
+    : `No problems detected yet. Live scanning will continue in the background.`;
 
   return (<Card>
     <CardContent>
-      <Typography variant="h5" component="h3">Ongoing Results</Typography>
+      <Typography variant="h4" component="h3">Ongoing Results</Typography>
       <Typography>{summaryTitle}</Typography>
-      <Typography color="text.secondary">{scansPassed} passed</Typography>
+      <Typography style={{color: theme.palette.text.secondary}}>{scansPassed} passed</Typography>
       <ul>
         {(severityCounts.critical > 0) && <li key="critical"><SeverityIcon severity='critical'/> {severityCounts.critical} Critical</li>}
         {(severityCounts.high > 0) && <li key="high"><SeverityIcon severity='high'/> {severityCounts.high} High</li>}

--- a/ui/components/app/theme.ts
+++ b/ui/components/app/theme.ts
@@ -1,0 +1,4 @@
+import { createTheme } from '@mui/material';
+
+export const theme = createTheme({
+});

--- a/ui/components/atoms/SeverityIcon/index.tsx
+++ b/ui/components/atoms/SeverityIcon/index.tsx
@@ -22,4 +22,4 @@ const Icons: Record<Severity, React.ReactElement> = {
 export const SeverityIcon: React.FC<{severity: Severity}> = ({severity}) =>
   Icons[severity] ?? Icons.none
 
-export const Checkmark = <CheckCircleOutline color='success'/>
+export const Checkmark: React.FC = () => <CheckCircleOutline color='success'/>

--- a/ui/components/atoms/Typography/Typography.tsx
+++ b/ui/components/atoms/Typography/Typography.tsx
@@ -8,6 +8,7 @@ export type TypographyProps = {
   component?: 'h1' | 'h2' | 'h3' | 'h4' | 'p' | string;
   variant?: TypographyVariant;
   children?: React.ReactNode;
+  style?: Partial<CSSStyleDeclaration>;
   className?: string;
 };
 
@@ -37,6 +38,7 @@ export const Typography = ({
   component,
   className,
   children,
+  style,
   variant = 'body1',
 }: TypographyProps): JSX.Element => {
   // in order, use:
@@ -50,5 +52,6 @@ export const Typography = ({
   const useClasses = classes[variant] ?? classes.body1;
   return React.createElement(useComponent, {
     className: clsx(useClasses, className),
+    style,
   }, children);
 };

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -36,7 +36,7 @@ export default function Dashboard() {
                 {summary && <Summary {...summary} />}
               </div>
             </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
+            <div className="grid grid-cols-1 mx-auto gap-8 mb-12">
               {(analyses.length > 0) && analyses.map((a) => <Analysis {...a} key={a.id}/>)}
               <div className="w-full bg-slate-200 h-[400px] rounded-lg flex justify-center items-center">
                 Table 2


### PR DESCRIPTION
Before you submit your PR, make sure you check each of the following:

1. [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and signed the [Contributor License Agreement](./CLA.md).
2. [x] My code is clean and ready-to-PR, including being free of lint errors and dead code
3. [x] I have **tested** my change / code and am confident that it works
4. [x] I have filled in the template below completely and accurately
##### Changelog
- Analysis Card was updated to include No Results variant. No Results is a thin, collapsed variant with the success color theme. Its body text is also zinc-400 to de-emphasize no-results scans.
- Extracted Weakness component inside Analysis Card, to reuse in both the No Results & Analysis renders
- Updated Summary Card to use `@/components/atoms/Typography`
- Updated Summary Card with enhanced "nothing doing" description, emphasizing that scanning is still running
- Updated the core `Layout` to include MUI's theme provider + `<CssBaseline>` component, required for theme engine

##### Testing

Used live data to generate views with and without findings during dev.

##### Unit Tests

Snapshot tests updated to match current state, see attached diffs

