### PR TITLE
[STR-4442]: Analyses Cards, Summary, responsiveness update

### DIFF
--- a/ui/components/app/Analysis/__snapshots__/ExpiredJWTCard.spec.tsx.snap
+++ b/ui/components/app/Analysis/__snapshots__/ExpiredJWTCard.spec.tsx.snap
@@ -3,20 +3,21 @@
 exports[`ExpiredJWTCard renders all passed props 1`] = `
 <DocumentFragment>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    aria-labelledby="title"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 MuiCard-root shadow-md css-935hc6-MuiPaper-root-MuiCard-root"
   >
     <div
-      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+      class="MuiCardContent-root p-0 last:pb-0 css-46bh2p-MuiCardContent-root"
     >
       <div
-        class="flex flex-nowrap"
+        class="flex flex-nowrap items-center px-2 py-4"
       >
         <h2
           class="leading-6 text-h2 font-poppins font-bold grow"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium css-1wxstni-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium mb-[3px] pb-[1px] css-1wxstni-MuiSvgIcon-root"
             data-testid="ErrorIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -29,7 +30,7 @@ exports[`ExpiredJWTCard renders all passed props 1`] = `
         </h2>
         <button
           aria-label="download data as CSV"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium p-0 mb-[3px] css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -51,7 +52,7 @@ exports[`ExpiredJWTCard renders all passed props 1`] = `
         </button>
       </div>
       <p
-        class="leading-6 text-body1 font-nunito max-w-prose my-2"
+        class="leading-6 text-body1 font-nunito max-w-prose pl-2.5 pr-6"
       >
         Test description
       </p>

--- a/ui/components/app/Analysis/__snapshots__/PasswordInURLCard.spec.tsx.snap
+++ b/ui/components/app/Analysis/__snapshots__/PasswordInURLCard.spec.tsx.snap
@@ -3,20 +3,21 @@
 exports[`ReusedAuthenticationCard renders all passed props 1`] = `
 <DocumentFragment>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    aria-labelledby="title"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 MuiCard-root shadow-md css-935hc6-MuiPaper-root-MuiCard-root"
   >
     <div
-      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+      class="MuiCardContent-root p-0 last:pb-0 css-46bh2p-MuiCardContent-root"
     >
       <div
-        class="flex flex-nowrap"
+        class="flex flex-nowrap items-center px-2 py-4"
       >
         <h2
           class="leading-6 text-h2 font-poppins font-bold grow"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium css-1wxstni-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium mb-[3px] pb-[1px] css-1wxstni-MuiSvgIcon-root"
             data-testid="ErrorIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -29,7 +30,7 @@ exports[`ReusedAuthenticationCard renders all passed props 1`] = `
         </h2>
         <button
           aria-label="download data as CSV"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium p-0 mb-[3px] css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -51,7 +52,7 @@ exports[`ReusedAuthenticationCard renders all passed props 1`] = `
         </button>
       </div>
       <p
-        class="leading-6 text-body1 font-nunito max-w-prose my-2"
+        class="leading-6 text-body1 font-nunito max-w-prose pl-2.5 pr-6"
       >
         Test description
       </p>

--- a/ui/components/app/Analysis/__snapshots__/ReusedAuthentication.spec.tsx.snap
+++ b/ui/components/app/Analysis/__snapshots__/ReusedAuthentication.spec.tsx.snap
@@ -3,20 +3,21 @@
 exports[`ReusedAuthenticationCard renders all passed props 1`] = `
 <DocumentFragment>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    aria-labelledby="title"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 MuiCard-root shadow-md css-935hc6-MuiPaper-root-MuiCard-root"
   >
     <div
-      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+      class="MuiCardContent-root p-0 last:pb-0 css-46bh2p-MuiCardContent-root"
     >
       <div
-        class="flex flex-nowrap"
+        class="flex flex-nowrap items-center px-2 py-4"
       >
         <h2
           class="leading-6 text-h2 font-poppins font-bold grow"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium css-1wxstni-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium mb-[3px] pb-[1px] css-1wxstni-MuiSvgIcon-root"
             data-testid="ErrorIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -29,7 +30,7 @@ exports[`ReusedAuthenticationCard renders all passed props 1`] = `
         </h2>
         <button
           aria-label="download data as CSV"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium p-0 mb-[3px] css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -51,7 +52,7 @@ exports[`ReusedAuthenticationCard renders all passed props 1`] = `
         </button>
       </div>
       <p
-        class="leading-6 text-body1 font-nunito max-w-prose my-2"
+        class="leading-6 text-body1 font-nunito max-w-prose pl-2.5 pr-6"
       >
         Test description
       </p>

--- a/ui/components/app/Analysis/__snapshots__/UseOfBasicAuthCard.spec.tsx.snap
+++ b/ui/components/app/Analysis/__snapshots__/UseOfBasicAuthCard.spec.tsx.snap
@@ -3,20 +3,21 @@
 exports[`UseOfBasicAuthCard renders all passed props 1`] = `
 <DocumentFragment>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    aria-labelledby="title"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 MuiCard-root shadow-md css-935hc6-MuiPaper-root-MuiCard-root"
   >
     <div
-      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+      class="MuiCardContent-root p-0 last:pb-0 css-46bh2p-MuiCardContent-root"
     >
       <div
-        class="flex flex-nowrap"
+        class="flex flex-nowrap items-center px-2 py-4"
       >
         <h2
           class="leading-6 text-h2 font-poppins font-bold grow"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium css-1wxstni-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium mb-[3px] pb-[1px] css-1wxstni-MuiSvgIcon-root"
             data-testid="ErrorIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -29,7 +30,7 @@ exports[`UseOfBasicAuthCard renders all passed props 1`] = `
         </h2>
         <button
           aria-label="download data as CSV"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium p-0 mb-[3px] css-1kuq5xv-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -51,7 +52,7 @@ exports[`UseOfBasicAuthCard renders all passed props 1`] = `
         </button>
       </div>
       <p
-        class="leading-6 text-body1 font-nunito max-w-prose my-2"
+        class="leading-6 text-body1 font-nunito max-w-prose pl-2.5 pr-6"
       >
         Test description
       </p>

--- a/ui/components/app/Analysis/core/CsvExportButton.tsx
+++ b/ui/components/app/Analysis/core/CsvExportButton.tsx
@@ -16,11 +16,11 @@ export type Props = {
    * clone of all the data and removing any `id` fields.
    */
   stripID?: true;
-}
+};
 
 // List of Windows-disallowed filename chars (in particular ':' might be found
 // inside timestamps)
-const UnsafeFilenameChars = /[\\\/\:\*\?\"\<\>\|]/g
+const UnsafeFilenameChars = /[\\\/\:\*\?\"\<\>\|]/g;
 
 export const CsvExportButton: React.FC<Props> = ({
   data,
@@ -33,7 +33,7 @@ export const CsvExportButton: React.FC<Props> = ({
     const sanitizedFilename = filename.replace(UnsafeFilenameChars, '_');
     if (stripID && !Array.isArray(csvData[0])) {
       csvData = csvData.map((datum) => {
-        const shallowClone = {...datum};
+        const shallowClone = { ...datum };
         // there is likely a better way of doing this,
         // but this is the way I know how to do it while
         // satisfying TypeScript types.
@@ -43,20 +43,25 @@ export const CsvExportButton: React.FC<Props> = ({
         return shallowClone;
       });
     }
-    const blob = new Blob([unparse(csvData, config)], {type: 'text/plain;charset=utf-8'});
+    const blob = new Blob([unparse(csvData, config)], {
+      type: 'text/plain;charset=utf-8',
+    });
     FileSaver.saveAs(blob, sanitizedFilename);
   }, [data, config, filename, stripID]);
 
-  return <Tooltip title='Download data as CSV'>
-    <IconButton
-      color='primary'
-      // Not sure why, but the ARIA example has the leading d lowercased in the
-      // label. Maybe the distinction is unimportant?
-      aria-label='download data as CSV'
-      component='button'
-      onClick={onClick}
-    >
-      <FileDownloadOutlined/>
-    </IconButton>
-  </Tooltip>
-}
+  return (
+    <Tooltip title="Download data as CSV">
+      <IconButton
+        color="primary"
+        className="p-0 mb-[3px]"
+        // Not sure why, but the ARIA example has the leading d lowercased in the
+        // label. Maybe the distinction is unimportant?
+        aria-label="download data as CSV"
+        component="button"
+        onClick={onClick}
+      >
+        <FileDownloadOutlined />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/ui/components/app/Analysis/core/__snapshots__/index.spec.tsx.snap
+++ b/ui/components/app/Analysis/core/__snapshots__/index.spec.tsx.snap
@@ -3,20 +3,21 @@
 exports[`AnalysisCard Does not render a WeaknessLink when given a title but no Link 1`] = `
 <DocumentFragment>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    aria-labelledby="title"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 MuiCard-root shadow-md css-935hc6-MuiPaper-root-MuiCard-root"
   >
     <div
-      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+      class="MuiCardContent-root p-0 last:pb-0 css-46bh2p-MuiCardContent-root"
     >
       <div
-        class="flex flex-nowrap"
+        class="flex flex-nowrap items-center px-2 py-4"
       >
         <h2
           class="leading-6 text-h2 font-poppins font-bold grow"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeMedium css-1yq1soz-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeMedium mb-[3px] pb-[1px] css-1yq1soz-MuiSvgIcon-root"
             data-testid="LightbulbIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -29,7 +30,7 @@ exports[`AnalysisCard Does not render a WeaknessLink when given a title but no L
         </h2>
       </div>
       <p
-        class="leading-6 text-body1 font-nunito max-w-prose my-2"
+        class="leading-6 text-body1 font-nunito max-w-prose pl-2.5 pr-6"
       >
         Test description
       </p>
@@ -63,20 +64,21 @@ exports[`AnalysisCard Does not render a WeaknessLink when given a title but no L
 exports[`AnalysisCard renders a weaknessLink without title 1`] = `
 <DocumentFragment>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    aria-labelledby="title"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 MuiCard-root shadow-md css-935hc6-MuiPaper-root-MuiCard-root"
   >
     <div
-      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+      class="MuiCardContent-root p-0 last:pb-0 css-46bh2p-MuiCardContent-root"
     >
       <div
-        class="flex flex-nowrap"
+        class="flex flex-nowrap items-center px-2 py-4"
       >
         <h2
           class="leading-6 text-h2 font-poppins font-bold grow"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeMedium css-1yq1soz-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeMedium mb-[3px] pb-[1px] css-1yq1soz-MuiSvgIcon-root"
             data-testid="LightbulbIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -89,7 +91,7 @@ exports[`AnalysisCard renders a weaknessLink without title 1`] = `
         </h2>
       </div>
       <p
-        class="leading-6 text-body1 font-nunito max-w-prose my-2"
+        class="leading-6 text-body1 font-nunito max-w-prose pl-2.5 pr-6"
       >
         Test description
       </p>
@@ -136,20 +138,21 @@ exports[`AnalysisCard renders a weaknessLink without title 1`] = `
 exports[`AnalysisCard renders all passed props 1`] = `
 <DocumentFragment>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+    aria-labelledby="title"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 MuiCard-root shadow-md css-935hc6-MuiPaper-root-MuiCard-root"
   >
     <div
-      class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+      class="MuiCardContent-root p-0 last:pb-0 css-46bh2p-MuiCardContent-root"
     >
       <div
-        class="flex flex-nowrap"
+        class="flex flex-nowrap items-center px-2 py-4"
       >
         <h2
           class="leading-6 text-h2 font-poppins font-bold grow"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeMedium css-1yq1soz-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeMedium mb-[3px] pb-[1px] css-1yq1soz-MuiSvgIcon-root"
             data-testid="LightbulbIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -162,7 +165,7 @@ exports[`AnalysisCard renders all passed props 1`] = `
         </h2>
       </div>
       <p
-        class="leading-6 text-body1 font-nunito max-w-prose my-2"
+        class="leading-6 text-body1 font-nunito max-w-prose pl-2.5 pr-6"
       >
         Test description
       </p>

--- a/ui/components/app/Analysis/core/index.tsx
+++ b/ui/components/app/Analysis/core/index.tsx
@@ -22,7 +22,7 @@ export type AnalysisProps = {
   noResults?: boolean;
 } & Pick<
   AnalysisType,
-  'description'
+  | 'description'
   | 'reportedAt'
   | 'weaknessLink'
   | 'weaknessTitle'
@@ -46,20 +46,19 @@ const ExpandMore = styled((props: ExpandMoreProps) => {
 }));
 
 const Weakness: React.FC<{
-  weaknessLink?: string
-  weaknessTitle?: string
-}> = ({ weaknessLink, weaknessTitle }) => (
-  weaknessLink
-  ? (
+  weaknessLink?: string;
+  weaknessTitle?: string;
+}> = ({ weaknessLink, weaknessTitle }) =>
+  weaknessLink ? (
     <tr>
       <td>Learn&nbsp;more:</td>
       <td>
-        <Link className='underline' href={weaknessLink}>{weaknessTitle ?? weaknessLink}</Link>
+        <Link className="underline" href={weaknessLink}>
+          {weaknessTitle ?? weaknessLink}
+        </Link>
       </td>
     </tr>
-  )
-  : null
-);
+  ) : null;
 
 const NoResults: React.FC<AnalysisProps> = ({
   description,
@@ -75,42 +74,53 @@ const NoResults: React.FC<AnalysisProps> = ({
     setExpanded(!expanded);
   };
 
-  return <Card className='max-w-prose -my-3'>
-    <CardContent className='flex items-center'>
-      <Typography
-        variant='h2'
-        className='font-light grow align-text-bottom'
-        style={{color: theme.palette.success.main}}
-      >
-        <Checkmark/>{' '}
-        {title}
-        {' - OK'}
-      </Typography>
-      <ExpandMore
-        expand={expanded}
-        onClick={handleExpandClick}
-        aria-expanded={expanded}
-        aria-label="show description"
-      >
-        <GridExpandMoreIcon/>
-      </ExpandMore>
-    </CardContent>
-    <Collapse in={expanded} timeout="auto" unmountOnExit>
-      <CardContent sx={{paddingTop: 0}}>
-        <Typography className='max-w-prose mb-4 text-zinc-400' variant='body1'>{description}</Typography>
-        <table className='font-light text-zinc-400 border-separate border-spacing-x-4'>
-          <tbody>
-            <tr>
-              <td>Updated:</td>
-              <td><FormattedDate when={reportedAt}/></td>
-            </tr>
-            <Weakness weaknessLink={weaknessLink} weaknessTitle={weaknessTitle}/>
-          </tbody>
-        </table>
+  return (
+    <Card className="max-w-prose -my-3">
+      <CardContent className="flex items-center">
+        <Typography
+          variant="h2"
+          className="font-light grow align-text-bottom"
+          style={{ color: theme.palette.success.main }}
+        >
+          <Checkmark /> {title}
+          {' - OK'}
+        </Typography>
+        <ExpandMore
+          expand={expanded}
+          onClick={handleExpandClick}
+          aria-expanded={expanded}
+          aria-label="show description"
+        >
+          <GridExpandMoreIcon />
+        </ExpandMore>
       </CardContent>
-    </Collapse>
-  </Card>
-}
+      <Collapse in={expanded} timeout="auto" unmountOnExit>
+        <CardContent sx={{ paddingTop: 0 }}>
+          <Typography
+            className="max-w-prose mb-4 text-zinc-400"
+            variant="body1"
+          >
+            {description}
+          </Typography>
+          <table className="font-light text-zinc-400 border-separate border-spacing-x-4">
+            <tbody>
+              <tr>
+                <td>Updated:</td>
+                <td>
+                  <FormattedDate when={reportedAt} />
+                </td>
+              </tr>
+              <Weakness
+                weaknessLink={weaknessLink}
+                weaknessTitle={weaknessTitle}
+              />
+            </tbody>
+          </table>
+        </CardContent>
+      </Collapse>
+    </Card>
+  );
+};
 
 export const AnalysisCard: React.FC<AnalysisProps> = ({
   description,
@@ -122,40 +132,54 @@ export const AnalysisCard: React.FC<AnalysisProps> = ({
   noResults,
   children,
   exportButton,
-}) => (
-  noResults
-  ? <NoResults {...{
-    description,
-    reportedAt,
-    weaknessLink,
-    weaknessTitle,
-    severity,
-    title,
-    noResults,
-  }}/>
-
-  : <Card>
-    <CardContent>
-      <div className='flex flex-nowrap'>
-        <Typography variant='h2' className='grow'><SeverityIcon severity={severity} /> {title}</Typography>
-        {exportButton}
-      </div>
-      <Typography className='max-w-prose my-2' variant='body1'>{description}</Typography>
-      <table className='font-light my-2 text-zinc-400 border-separate border-spacing-x-4'>
-        <tbody>
-          <tr>
-            <td>Updated:</td><td><FormattedDate when={reportedAt} /></td>
-          </tr>
-          <tr>
-            <td>Issue Severity:</td><td>{severity}</td>
-          </tr>
-          <Weakness weaknessLink={weaknessLink} weaknessTitle={weaknessTitle}/>
-        </tbody>
-      </table>
-      {children}
-    </CardContent>
-  </Card>
-);
+}) =>
+  noResults ? (
+    <NoResults
+      {...{
+        description,
+        reportedAt,
+        weaknessLink,
+        weaknessTitle,
+        severity,
+        title,
+        noResults,
+      }}
+    />
+  ) : (
+    <Card aria-labelledby="title" className="shadow-md" elevation={2}>
+      <CardContent className="p-0 last:pb-0">
+        <div className="flex flex-nowrap items-center px-2 py-4">
+          <Typography variant="h2" className="grow" aria-label="title">
+            <SeverityIcon className="mb-[3px] pb-[1px]" severity={severity} />{' '}
+            {title}
+          </Typography>
+          {exportButton}
+        </div>
+        <Typography className="max-w-prose pl-2.5 pr-6" variant="body1">
+          {description}
+        </Typography>
+        <table className="font-light my-2 text-zinc-400 border-separate border-spacing-x-4">
+          <tbody>
+            <tr>
+              <td>Updated:</td>
+              <td>
+                <FormattedDate when={reportedAt} />
+              </td>
+            </tr>
+            <tr>
+              <td>Issue Severity:</td>
+              <td>{severity}</td>
+            </tr>
+            <Weakness
+              weaknessLink={weaknessLink}
+              weaknessTitle={weaknessTitle}
+            />
+          </tbody>
+        </table>
+        {children}
+      </CardContent>
+    </Card>
+  );
 
 export const AnalysisCardLoading = () => {
   return (

--- a/ui/components/app/Header/Header.tsx
+++ b/ui/components/app/Header/Header.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 export const Header = () => {
   return (
     <header className="h-[72px] bg-corsha-brand-blue flex w-screen m-0 justify-start items-center border-b-2 border-b-green-700">
-      <nav className="flex flex-1 max-w-screen mx-auto px-4 sm:px-6 lg:px-8 items-center">
+      <nav className="flex flex-1 max-w-screen 2xl:max-4K:max-w-10xl mx-auto px-4 sm:px-6 lg:px-8 items-center">
         <ul>
           <li>
             <Link href="/" className="text-white">

--- a/ui/components/app/Summary/__snapshots__/Summary.spec.tsx.snap
+++ b/ui/components/app/Summary/__snapshots__/Summary.spec.tsx.snap
@@ -2,21 +2,21 @@
 
 exports[`Analyses Summary Component renders all problems variant 1`] = `
 <div
-  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root w-full h-full css-bhp9pd-MuiPaper-root-MuiCard-root"
 >
   <div
-    className="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+    className="MuiCardContent-root flex flex-col space-y-5 px-4 py-8 css-46bh2p-MuiCardContent-root"
   >
-    <h3
-      className="leading-6 text-h4 font-poppins font-semibold"
+    <h1
+      className="leading-6 text-h1 font-poppins font-bold"
     >
       Ongoing Results
-    </h3>
-    <p
-      className="leading-6 text-body1 font-nunito"
+    </h1>
+    <h4
+      className="leading-6 text-h4 font-poppins font-semibold"
     >
       7 Faults (143 Findings)
-    </p>
+    </h4>
     <p
       className="leading-6 text-body1 font-nunito"
       style={
@@ -28,11 +28,15 @@ exports[`Analyses Summary Component renders all problems variant 1`] = `
       10
        passed
     </p>
-    <ul>
-      <li>
+    <ul
+      className="max-h-40 overflow-y-scroll space-y-1 flex flex-col justify-center pt-1"
+    >
+      <li
+        className="flex items-center text-lg font-semibold"
+      >
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium css-1wxstni-MuiSvgIcon-root"
+          className="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium mr-2 css-1wxstni-MuiSvgIcon-root"
           data-testid="CrisisAlertIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -45,10 +49,12 @@ exports[`Analyses Summary Component renders all problems variant 1`] = `
         5
          Critical
       </li>
-      <li>
+      <li
+        className="flex items-center text-lg font-semibold"
+      >
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium css-1wxstni-MuiSvgIcon-root"
+          className="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium mr-2 css-1wxstni-MuiSvgIcon-root"
           data-testid="ErrorIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -61,10 +67,12 @@ exports[`Analyses Summary Component renders all problems variant 1`] = `
         4
          High
       </li>
-      <li>
+      <li
+        className="flex items-center text-lg font-semibold"
+      >
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeMedium css-3adcp6-MuiSvgIcon-root"
+          className="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeMedium mr-2 css-3adcp6-MuiSvgIcon-root"
           data-testid="WarningIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -77,10 +85,12 @@ exports[`Analyses Summary Component renders all problems variant 1`] = `
         3
          Medium
       </li>
-      <li>
+      <li
+        className="flex items-center text-lg font-semibold"
+      >
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeMedium css-3adcp6-MuiSvgIcon-root"
+          className="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeMedium mr-2 css-3adcp6-MuiSvgIcon-root"
           data-testid="DarkModeIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -93,10 +103,12 @@ exports[`Analyses Summary Component renders all problems variant 1`] = `
         2
          Low
       </li>
-      <li>
+      <li
+        className="flex items-center text-lg font-semibold"
+      >
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeMedium css-1yq1soz-MuiSvgIcon-root"
+          className="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeMedium mr-2 css-1yq1soz-MuiSvgIcon-root"
           data-testid="LightbulbIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -116,21 +128,21 @@ exports[`Analyses Summary Component renders all problems variant 1`] = `
 
 exports[`Analyses Summary Component renders no problems variant 1`] = `
 <div
-  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root w-full h-full css-bhp9pd-MuiPaper-root-MuiCard-root"
 >
   <div
-    className="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+    className="MuiCardContent-root flex flex-col space-y-5 px-4 py-8 css-46bh2p-MuiCardContent-root"
   >
-    <h3
-      className="leading-6 text-h4 font-poppins font-semibold"
+    <h1
+      className="leading-6 text-h1 font-poppins font-bold"
     >
       Ongoing Results
-    </h3>
-    <p
-      className="leading-6 text-body1 font-nunito"
+    </h1>
+    <h4
+      className="leading-6 text-h4 font-poppins font-semibold"
     >
       No problems detected yet. Live scanning will continue in the background.
-    </p>
+    </h4>
     <p
       className="leading-6 text-body1 font-nunito"
       style={
@@ -142,28 +154,30 @@ exports[`Analyses Summary Component renders no problems variant 1`] = `
       17
        passed
     </p>
-    <ul />
+    <ul
+      className="max-h-40 overflow-y-scroll space-y-1 flex flex-col justify-center pt-1"
+    />
   </div>
 </div>
 `;
 
 exports[`Analyses Summary Component renders some problems variant 1`] = `
 <div
-  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-bhp9pd-MuiPaper-root-MuiCard-root"
+  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root w-full h-full css-bhp9pd-MuiPaper-root-MuiCard-root"
 >
   <div
-    className="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+    className="MuiCardContent-root flex flex-col space-y-5 px-4 py-8 css-46bh2p-MuiCardContent-root"
   >
-    <h3
-      className="leading-6 text-h4 font-poppins font-semibold"
+    <h1
+      className="leading-6 text-h1 font-poppins font-bold"
     >
       Ongoing Results
-    </h3>
-    <p
-      className="leading-6 text-body1 font-nunito"
+    </h1>
+    <h4
+      className="leading-6 text-h4 font-poppins font-semibold"
     >
       7 Faults (143 Findings)
-    </p>
+    </h4>
     <p
       className="leading-6 text-body1 font-nunito"
       style={
@@ -175,11 +189,15 @@ exports[`Analyses Summary Component renders some problems variant 1`] = `
       10
        passed
     </p>
-    <ul>
-      <li>
+    <ul
+      className="max-h-40 overflow-y-scroll space-y-1 flex flex-col justify-center pt-1"
+    >
+      <li
+        className="flex items-center text-lg font-semibold"
+      >
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium css-1wxstni-MuiSvgIcon-root"
+          className="MuiSvgIcon-root MuiSvgIcon-colorError MuiSvgIcon-fontSizeMedium mr-2 css-1wxstni-MuiSvgIcon-root"
           data-testid="CrisisAlertIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -192,10 +210,12 @@ exports[`Analyses Summary Component renders some problems variant 1`] = `
         3
          Critical
       </li>
-      <li>
+      <li
+        className="flex items-center text-lg font-semibold"
+      >
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeMedium css-3adcp6-MuiSvgIcon-root"
+          className="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeMedium mr-2 css-3adcp6-MuiSvgIcon-root"
           data-testid="WarningIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -208,10 +228,12 @@ exports[`Analyses Summary Component renders some problems variant 1`] = `
         2
          Medium
       </li>
-      <li>
+      <li
+        className="flex items-center text-lg font-semibold"
+      >
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeMedium css-3adcp6-MuiSvgIcon-root"
+          className="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeMedium mr-2 css-3adcp6-MuiSvgIcon-root"
           data-testid="DarkModeIcon"
           focusable="false"
           viewBox="0 0 24 24"

--- a/ui/components/app/Summary/index.tsx
+++ b/ui/components/app/Summary/index.tsx
@@ -5,44 +5,98 @@ import { SeverityIcon, Typography } from '@/components/atoms';
 
 type SummaryProps = AnalysesSummary;
 
-export const Summary = ({ faults, findings, scansPassed, severityCounts }: SummaryProps) => {
+export const Summary = ({
+  faults,
+  findings,
+  scansPassed,
+  severityCounts,
+}: SummaryProps) => {
   const theme = useTheme();
   const summaryTitle = faults
     ? `${faults} Faults (${findings} Findings)`
     : `No problems detected yet. Live scanning will continue in the background.`;
 
-  return (<Card>
-    <CardContent>
-      <Typography variant="h4" component="h3">Ongoing Results</Typography>
-      <Typography>{summaryTitle}</Typography>
-      <Typography style={{color: theme.palette.text.secondary}}>{scansPassed} passed</Typography>
-      <ul>
-        {(severityCounts.critical > 0) && <li key="critical"><SeverityIcon severity='critical' /> {severityCounts.critical} Critical</li>}
-        {(severityCounts.high > 0) && <li key="high"><SeverityIcon severity='high' /> {severityCounts.high} High</li>}
-        {(severityCounts.medium > 0) && <li key="medium"><SeverityIcon severity='medium' /> {severityCounts.medium} Medium</li>}
-        {(severityCounts.low > 0) && <li key="low"><SeverityIcon severity='low' /> {severityCounts.low} Low</li>}
-        {(severityCounts.none > 0) && <li key="none"><SeverityIcon severity='none' /> {severityCounts.none} None</li>}
-      </ul>
-    </CardContent>
-  </Card>);
-}
+  return (
+    <Card className="w-full h-full">
+      <CardContent className="flex flex-col space-y-5 px-4 py-8">
+        <Typography variant="h1" component="h1">
+          Ongoing Results
+        </Typography>
+        <Typography variant="h4" component="h4">
+          {summaryTitle}
+        </Typography>
+        <Typography style={{ color: theme.palette.text.secondary }}>
+          {scansPassed} passed
+        </Typography>
+        <ul className="max-h-40 overflow-y-scroll space-y-1 flex flex-col justify-center pt-1">
+          {severityCounts.critical > 0 && (
+            <li
+              key="critical"
+              className="flex items-center text-lg font-semibold"
+            >
+              <SeverityIcon severity="critical" className="mr-2" />{' '}
+              {severityCounts.critical} Critical
+            </li>
+          )}
+          {severityCounts.high > 0 && (
+            <li key="high" className="flex items-center text-lg font-semibold">
+              <SeverityIcon severity="high" className="mr-2" />{' '}
+              {severityCounts.high} High
+            </li>
+          )}
+          {severityCounts.medium > 0 && (
+            <li
+              key="medium"
+              className="flex items-center text-lg font-semibold"
+            >
+              <SeverityIcon severity="medium" className="mr-2" />{' '}
+              {severityCounts.medium} Medium
+            </li>
+          )}
+          {severityCounts.low > 0 && (
+            <li key="low" className="flex items-center text-lg font-semibold">
+              <SeverityIcon severity="low" className="mr-2" />{' '}
+              {severityCounts.low} Low
+            </li>
+          )}
+          {severityCounts.none > 0 && (
+            <li key="none" className="flex items-center text-lg font-semibold">
+              <SeverityIcon severity="none" className="mr-2" />{' '}
+              {severityCounts.none} None
+            </li>
+          )}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+};
 
 export const SummaryLoading = () => {
   const theme = useTheme();
-  const liClassName = 'w-32 h-2.5 bg-gray-200 rounded-full dark:bg-gray-500 mb-2';
+  const liClassName =
+    'w-32 h-2.5 bg-gray-200 rounded-full dark:bg-gray-500 mb-2';
 
-  return (<Card className="animate-pulse">
-    <CardContent>
-      <Typography variant="h4" component="h3" className="h-5 bg-gray-200 rounded-full dark:bg-gray-500 w-48 mb-2"></Typography>
-      <Typography className="h-2.5 bg-gray-200 rounded-full dark:bg-gray-500 w-40 mb-2"></Typography>
-      <Typography className="h-2 bg-gray-200 rounded-full dark:bg-gray-500 w-20 mb-2" style={{color: theme.palette.text.secondary}}></Typography>
-      <ul>
-        <li className={liClassName} key="critical"></li>
-        <li className={liClassName} key="high"></li>
-        <li className={liClassName} key="medium"></li>
-        <li className={liClassName} key="low"></li>
-        <li className={liClassName} key="none"></li>
-      </ul>
-    </CardContent>
-  </Card>);
-}
+  return (
+    <Card className="animate-pulse">
+      <CardContent>
+        <Typography
+          variant="h4"
+          component="h3"
+          className="h-5 bg-gray-200 rounded-full dark:bg-gray-500 w-48 mb-2"
+        ></Typography>
+        <Typography className="h-2.5 bg-gray-200 rounded-full dark:bg-gray-500 w-40 mb-2"></Typography>
+        <Typography
+          className="h-2 bg-gray-200 rounded-full dark:bg-gray-500 w-20 mb-2"
+          style={{ color: theme.palette.text.secondary }}
+        ></Typography>
+        <ul>
+          <li className={liClassName} key="critical"></li>
+          <li className={liClassName} key="high"></li>
+          <li className={liClassName} key="medium"></li>
+          <li className={liClassName} key="low"></li>
+          <li className={liClassName} key="none"></li>
+        </ul>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/components/app/page-sections/TypographySection/__snapshots__/TypographySection.spec.tsx.snap
+++ b/ui/components/app/page-sections/TypographySection/__snapshots__/TypographySection.spec.tsx.snap
@@ -43,54 +43,54 @@ exports[`Typography Section snapshot 1`] = `
       <p
         className="leading-6 text-body1 font-nunito"
       >
-        <div
+        <span
           className="font-black"
         >
           Body 1 Black
-        </div>
-        <div
+        </span>
+        <span
           className="font-black"
         >
           Nunito Sans Black 16px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body1 font-nunito"
       >
-        <div
+        <span
           className="font-bold"
         >
           Body 1 Bold
-        </div>
-        <div
+        </span>
+        <span
           className="font-bold"
         >
           Nunito Sans Bold 16px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body1 font-nunito"
       >
-        <div>
+        <span>
           Body 1 Regular
-        </div>
-        <div>
+        </span>
+        <span>
           Nunito Sans Regular 16px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body1 font-nunito"
       >
-        <div
+        <span
           className="underline font-medium"
         >
           Body 1 Underlined
-        </div>
-        <div
+        </span>
+        <span
           className="underline font-medium"
         >
           Nunito Sans Medium Underline 16px
-        </div>
+        </span>
       </p>
     </div>
     <div
@@ -99,54 +99,54 @@ exports[`Typography Section snapshot 1`] = `
       <p
         className="leading-6 text-body2 font-nunito"
       >
-        <div
+        <span
           className="font-bold"
         >
           Body 2 Bold
-        </div>
-        <div
+        </span>
+        <span
           className="font-bold"
         >
           Nunito Sans Bold 14px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body2 font-nunito"
       >
-        <div>
+        <span>
           Body 2 Regular
-        </div>
-        <div>
+        </span>
+        <span>
           Nunito Sans Regular 14px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body2 font-nunito"
       >
-        <div
+        <span
           className="underline font-medium"
         >
           Body 2 Underlined
-        </div>
-        <div
+        </span>
+        <span
           className="underline font-medium"
         >
           Nunito Sans Medium Underline 14px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body2 font-nunito"
       >
-        <div
+        <span
           className="font-medium"
         >
           All Caps
-        </div>
-        <div
+        </span>
+        <span
           className="font-black capitalize"
         >
           Nunito Sans Black All Caps 14px
-        </div>
+        </span>
       </p>
     </div>
     <div
@@ -155,54 +155,54 @@ exports[`Typography Section snapshot 1`] = `
       <p
         className="leading-6 text-body3 font-nunito"
       >
-        <div
+        <span
           className="font-black"
         >
           Body 3 Black
-        </div>
-        <div
+        </span>
+        <span
           className="font-black"
         >
           Nunito Sans Black 12px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body3 font-nunito"
       >
-        <div
+        <span
           className="font-bold"
         >
           Body 3 Bold
-        </div>
-        <div
+        </span>
+        <span
           className="font-bold"
         >
           Nunito Sans Bold 12px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body3 font-nunito"
       >
-        <div>
+        <span>
           Body 3 Regular
-        </div>
-        <div>
+        </span>
+        <span>
           Nunito Sans Regular 12px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body3 font-nunito"
       >
-        <div
+        <span
           className="underline font-medium"
         >
           Body 3 Underlined
-        </div>
-        <div
+        </span>
+        <span
           className="underline font-medium"
         >
           Nunito Sans Medium Underline 12px
-        </div>
+        </span>
       </p>
     </div>
     <div
@@ -211,54 +211,54 @@ exports[`Typography Section snapshot 1`] = `
       <p
         className="leading-6 text-body4 font-nunito"
       >
-        <div
+        <span
           className="font-black"
         >
           Body 4 Black
-        </div>
-        <div
+        </span>
+        <span
           className="font-black"
         >
           Nunito Sans Black 10px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body4 font-nunito"
       >
-        <div
+        <span
           className="font-bold"
         >
           Body 4 Bold
-        </div>
-        <div
+        </span>
+        <span
           className="font-bold"
         >
           Nunito Sans Bold 10px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body4 font-nunito"
       >
-        <div>
+        <span>
           Body 4 Regular
-        </div>
-        <div>
+        </span>
+        <span>
           Nunito Sans Regular 10px
-        </div>
+        </span>
       </p>
       <p
         className="leading-6 text-body4 font-nunito"
       >
-        <div
+        <span
           className="underline font-medium"
         >
           Body 4 Underlined
-        </div>
-        <div
+        </span>
+        <span
           className="underline font-medium"
         >
           Nunito Sans Medium Underline 10px
-        </div>
+        </span>
       </p>
     </div>
   </div>,

--- a/ui/components/app/page-sections/TypographySection/index.tsx
+++ b/ui/components/app/page-sections/TypographySection/index.tsx
@@ -24,84 +24,84 @@ export const TypographySection = () => {
         </Typography>
         <div className="grid grid-cols-4 justify-between items-start pt-12">
           <Typography variant="body1">
-            <div className="font-black">Body 1 Black</div>
-            <div className="font-black">Nunito Sans Black 16px</div>
+            <span className="font-black">Body 1 Black</span>
+            <span className="font-black">Nunito Sans Black 16px</span>
           </Typography>
           <Typography variant="body1">
-            <div className="font-bold">Body 1 Bold</div>
-            <div className="font-bold">Nunito Sans Bold 16px</div>
+            <span className="font-bold">Body 1 Bold</span>
+            <span className="font-bold">Nunito Sans Bold 16px</span>
           </Typography>
           <Typography variant="body1">
-            <div>Body 1 Regular</div>
-            <div>Nunito Sans Regular 16px</div>
+            <span>Body 1 Regular</span>
+            <span>Nunito Sans Regular 16px</span>
           </Typography>
           <Typography variant="body1">
-            <div className="underline font-medium">Body 1 Underlined</div>
-            <div className="underline font-medium">
+            <span className="underline font-medium">Body 1 Underlined</span>
+            <span className="underline font-medium">
               Nunito Sans Medium Underline 16px
-            </div>
+            </span>
           </Typography>
         </div>
         <div className="grid grid-cols-4 justify-between items-start pt-12">
           <Typography variant="body2">
-            <div className="font-bold">Body 2 Bold</div>
-            <div className="font-bold">Nunito Sans Bold 14px</div>
+            <span className="font-bold">Body 2 Bold</span>
+            <span className="font-bold">Nunito Sans Bold 14px</span>
           </Typography>
           <Typography variant="body2">
-            <div>Body 2 Regular</div>
-            <div>Nunito Sans Regular 14px</div>
+            <span>Body 2 Regular</span>
+            <span>Nunito Sans Regular 14px</span>
           </Typography>
           <Typography variant="body2">
-            <div className="underline font-medium">Body 2 Underlined</div>
-            <div className="underline font-medium">
+            <span className="underline font-medium">Body 2 Underlined</span>
+            <span className="underline font-medium">
               Nunito Sans Medium Underline 14px
-            </div>
+            </span>
           </Typography>
           <Typography variant="body2">
-            <div className="font-medium">All Caps</div>
-            <div className="font-black capitalize">
+            <span className="font-medium">All Caps</span>
+            <span className="font-black capitalize">
               Nunito Sans Black All Caps 14px
-            </div>
+            </span>
           </Typography>
         </div>
         <div className="grid grid-cols-4 justify-between items-start pt-12">
           <Typography variant="body3">
-            <div className="font-black">Body 3 Black</div>
-            <div className="font-black">Nunito Sans Black 12px</div>
+            <span className="font-black">Body 3 Black</span>
+            <span className="font-black">Nunito Sans Black 12px</span>
           </Typography>
           <Typography variant="body3">
-            <div className="font-bold">Body 3 Bold</div>
-            <div className="font-bold">Nunito Sans Bold 12px</div>
+            <span className="font-bold">Body 3 Bold</span>
+            <span className="font-bold">Nunito Sans Bold 12px</span>
           </Typography>
           <Typography variant="body3">
-            <div>Body 3 Regular</div>
-            <div>Nunito Sans Regular 12px</div>
+            <span>Body 3 Regular</span>
+            <span>Nunito Sans Regular 12px</span>
           </Typography>
           <Typography variant="body3">
-            <div className="underline font-medium">Body 3 Underlined</div>
-            <div className="underline font-medium">
+            <span className="underline font-medium">Body 3 Underlined</span>
+            <span className="underline font-medium">
               Nunito Sans Medium Underline 12px
-            </div>
+            </span>
           </Typography>
         </div>
         <div className="grid grid-cols-4 justify-between items-start pt-12">
           <Typography variant="body4">
-            <div className="font-black">Body 4 Black</div>
-            <div className="font-black">Nunito Sans Black 10px</div>
+            <span className="font-black">Body 4 Black</span>
+            <span className="font-black">Nunito Sans Black 10px</span>
           </Typography>
           <Typography variant="body4">
-            <div className="font-bold">Body 4 Bold</div>
-            <div className="font-bold">Nunito Sans Bold 10px</div>
+            <span className="font-bold">Body 4 Bold</span>
+            <span className="font-bold">Nunito Sans Bold 10px</span>
           </Typography>
           <Typography variant="body4">
-            <div>Body 4 Regular</div>
-            <div>Nunito Sans Regular 10px</div>
+            <span>Body 4 Regular</span>
+            <span>Nunito Sans Regular 10px</span>
           </Typography>
           <Typography variant="body4">
-            <div className="underline font-medium">Body 4 Underlined</div>
-            <div className="underline font-medium">
+            <span className="underline font-medium">Body 4 Underlined</span>
+            <span className="underline font-medium">
               Nunito Sans Medium Underline 10px
-            </div>
+            </span>
           </Typography>
         </div>
       </div>

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -9,21 +9,28 @@ import { Layout, Summary, SummaryLoading } from '@/components/index';
 import { summarizeAnalyses } from 'lib/findings';
 
 const AnalysisGridLoading = () => {
-  return (<>
-    <AnalysisCardLoading />
-    <AnalysisCardLoading />
-    <AnalysisCardLoading />
-    <AnalysisCardLoading />
-  </>);
-}
+  return (
+    <>
+      <AnalysisCardLoading />
+      <AnalysisCardLoading />
+      <AnalysisCardLoading />
+      <AnalysisCardLoading />
+    </>
+  );
+};
 
 export default function Dashboard() {
-  const { data, isLoading, error } = useSWR<AnalysesResponse>('/api/analyses');
-  const analysesResponse = data;
+  const {
+    data: analysesResponse,
+    isLoading,
+    error,
+  } = useSWR<AnalysesResponse>('/api/analyses');
 
-  const summary = !isLoading && analysesResponse && summarizeAnalyses(analysesResponse.analyses);
-  const analyses = analysesResponse?.analyses ?? []
-  const showLoadingState = error || isLoading;
+  const summary =
+    !isLoading &&
+    analysesResponse &&
+    summarizeAnalyses(analysesResponse.analyses);
+  const analyses = analysesResponse?.analyses ?? [];
 
   return (
     <>
@@ -33,17 +40,22 @@ export default function Dashboard() {
       <Layout>
         <Header />
         <main className="bg-gray-50 w-screen">
-          {error && <Alert severity="error"> An Error Occurred loading analysis: {error.toString()} </Alert>}
-          <div className="max-w-screen mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="mx-auto">
-              <div className="w-full my-12 bg-slate-200 h-[400px] rounded-lg flex justify-center items-center">
-                {summary && <Summary {...summary} />}
-                {showLoadingState && <SummaryLoading />}
-              </div>
+          {error && (
+            <Alert severity="error">
+              An Error Occurred loading analysis: {error.toString()}
+            </Alert>
+          )}
+          <div className="max-w-screen 2xl:max-4K:max-w-10xl  mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="my-12">
+              {summary ? <Summary {...summary} /> : <SummaryLoading />}
             </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
-              {(analyses.length > 0) && analyses.map((a) => <Analysis {...a} key={a.id} />)}
-              {showLoadingState && <AnalysisGridLoading />}
+
+            <div className="flex flex-col 4K:grid 4K:grid-cols-2 space-y-12 4K:space-y-0 4K:gap-4 mb-12">
+              {analyses.length > 0 ? (
+                analyses.map((a) => <Analysis {...a} key={a.id} />)
+              ) : (
+                <AnalysisGridLoading />
+              )}
             </div>
           </div>
         </main>

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -57,6 +57,14 @@ module.exports = {
         'icon-md': '1.25rem',
         'icon-lg': '1.5rem',
       },
+      maxWidth: {
+        '8xl': '88rem',
+        '9xl': '96rem',
+        '10xl': '104rem',
+      },
+      screens: {
+        '4K': '2560px',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Before you submit your PR, make sure you check each of the following:

1. [X] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and signed the [Contributor License Agreement](./CLA.md).
2. [X] My code is clean and ready-to-PR, including being free of lint errors and dead code
3. [X] I have **tested** my change / code and am confident that it works
4. [x] I have filled in the template below completely and accurately
##### Changelog

This is the first of 3 PR's this sprint to update the overall styles on the main page (dashboard).

In Analyses Cards, styles were added to update alignment in the title (and corresponding icon), and descriptive text
On main page, the layout was updated to explore ways to adjust to positioning based on content in tables. 

One thing of note is that by stacking the cards on top of each other, they don't contain empty white space at the bottom of any of them. To properly get the benefits of putting them side by side, the descriptive text needs to be able to be collapsed by default, making all the cards the same height. In the next PR (or this one) I'd be comfortable with just stacking them on top of each other.

Summary card updated, targeting Mobile screens first. Severity results are stacked vertically with a max of 5 expected, any more than that cause the `ul` to scroll. Skeleton will be next.

Hydration errors from TypographySection removed.

##### Testing

Observe that the Summary Card now fills the space in which it is allotted 
Adjust your browser window's width and observe that when available, the entire tables' contents are viewable.
On smaller screens, the content doesn't break the containing div which it's in (there's no weird overflow issues).

##### Unit Tests

snapshots updated

