### PR TITLE
Str 4443 kubeshark 38

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ certain parameters.
 | `postgresql.auth.database` | Postgres database name | `""` |
 | `postgresql.auth.password` | Postgres database password. If this is not set, a random password will be generated. | `""` |
 | `collector.env.PGPORT` | Which port postgres is using | `""` |
-| `collector.env.WEBSOCKET_URL` | The web socket Kubeshark has attached to | `""` |
+| `collector.env.KUBESHARK_HUB_URL` | URL to the Kubeshark HUB | `""` |
 | `collector.image.tag` | The tag of the cast/collector image | `""` |
 | `collector.image.repository` | The repository of the cast/collector image | `""` |
 | `ui.env.PGPORT` | Which port postgres is using | `""` |

--- a/TESTING.md
+++ b/TESTING.md
@@ -19,8 +19,20 @@ Some components may still be running if you have run Skaffold
 before. From the root of the project, run the following set of command
 to ensure everything is clean before testing features.
 
+```bash
+skaffold delete 
+```
+
 You may see error messages like the follow if your state is already
 clean.
+
+```text
+Cleaning up...
+Error: uninstall: Release not loaded: cast: release: not found
+Error: uninstall: Release not loaded: httpbin: release: not found
+exit status 1
+exit status 1
+```
 
 ## Deploying the test stack
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -425,6 +425,11 @@ func hubURLToWebsocketURL(hubURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not parse Kubeshark Hub URL: %w", err)
 	}
+
+	// Lint disabled because it the constant would not mean the same
+	// thing and the two strings are only used here.
+	//
+	// nolint:goconst
 	url.Scheme = "ws"
 	url.Path = "ws"
 	return url.String(), nil

--- a/collector/internal/test/kubeshark/v38.go
+++ b/collector/internal/test/kubeshark/v38.go
@@ -1,0 +1,77 @@
+// kubeshark implements a test service that mimics the Kubeshark 38 Hub API
+package kubeshark
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	"github.com/julienschmidt/httprouter"
+	"github.com/sirupsen/logrus"
+)
+
+type Service struct {
+	Handler http.Handler
+
+	messages chan string
+	data     map[string]string
+}
+
+// New creates a new
+func New() *Service {
+	service := &Service{
+		messages: make(chan string, 100),
+		data:     map[string]string{},
+		Handler:  nil,
+	}
+
+	router := httprouter.New()
+	router.GET("/ws", service.echo)
+	router.GET("/item/:worker/:id", service.item)
+
+	service.Handler = router
+
+	return service
+}
+
+type Message struct {
+	Id string `json:"id"`
+}
+
+func (service *Service) Send(messageJson string, pcapJson string) {
+	message := Message{}
+	err := json.Unmarshal([]byte(messageJson), &message)
+	if err != nil {
+		logrus.WithError(err).Debug("error parsing test message Json")
+	}
+	service.messages <- messageJson
+	service.data[message.Id] = pcapJson
+}
+
+var upgrader = websocket.Upgrader{}
+
+func (service *Service) echo(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer c.Close()
+	for {
+		message := <-service.messages
+		err = c.WriteMessage(websocket.TextMessage, []byte(message))
+		if err != nil {
+			break
+		}
+	}
+}
+
+func (service *Service) item(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	key := fmt.Sprintf("%s/%s", ps.ByName("worker"), ps.ByName("id"))
+	pcap, found := service.data[key]
+	if !found {
+		w.WriteHeader(404)
+		return
+	}
+	fmt.Fprintf(w, "%s", pcap)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/emirpasic/gods v1.18.1
 	github.com/gorilla/websocket v1.5.0
+	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.7
 	github.com/sirupsen/logrus v1.8.0
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=

--- a/k8s/helm/cast/values.yaml
+++ b/k8s/helm/cast/values.yaml
@@ -49,7 +49,8 @@ postgresql:
 collector:
   env:
     PGPORT: "5432"
-    WEBSOCKET_URL: "ws://kubeshark-api-server.kubeshark.svc.cluster.local/ws"
+    KUBESHARK_HUB_URL: "http://kubeshark-hub.kubeshark.svc.cluster.local"
+
   image:
     tag: ""
     repository: ghcr.io/corshatech/cast/collector


### PR DESCRIPTION
Before you submit your PR, make sure you check each of the following:

1. [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and signed the [Contributor License Agreement](./CLA.md).
2. [x] My code is clean and ready-to-PR, including being free of lint errors and dead code
3. [x] I have **tested** my change / code and am confident that it works
4. [x] I have filled in the template below completely and accurately

##### Changelog

- Upgrade collector to work with Kubeshark 38

##### Testing
```sh
cd ~
rm -rf /tmp/str-4443
mkdir /tmp/str-4443
cd /tmp/str-4443

ln -s ~/src/cast /tmp/str-4443/cast
```

Download version 37 of Kubeshark by following the instructions at <https://github.com/kubeshark/kubeshark/releases/tag/37.0>

```sh
# Intel Mac
curl -Lo kubeshark https://github.com/kubeshark/kubeshark/releases/download/37.0/kubeshark_darwin_amd64 && chmod 755 kubeshark

# M1
curl -Lo kubeshark https://github.com/kubeshark/kubeshark/releases/download/37.0/kubeshark_darwin_arm64 && chmod 755 kubeshark

./kubeshark version
```

Run the old version of CAST

```sh
cd /tmp/str-4443/cast
git checkout 80d0ec9e877ccf33d1770afbc079a64a07337550
export PATH="/tmp/str-4443:$PATH"
# verify that the version of kubeshark is 37.0
kubeshark version
```

Clean up everything

```sh
kubeshark --set kube-context=docker-desktop clean
skaffold delete --kube-context docker-desktop # ignore any errors about missing releases
kubectl --context docker-desktop delete ns cast
kubectl --context docker-desktop delete ns kubeshark
```

Start the test Skaffold

```sh
skaffold run --platform=linux/amd64 --port-forward --kube-context docker-desktop
```

Wait for the following log messages

    Port forwarding service/cast-postgresql in namespace cast, remote port 5432 -> http://127.0.0.1:5432
    Port forwarding service/cast-service in namespace cast, remote port 80 -> http://127.0.0.1:8000
    Port forwarding service/httpbin in namespace cast, remote port 80 -> http://127.0.0.1:8080
    Port forwarding service/cast-postgresql-hl in namespace cast, remote port 5432 -> http://127.0.0.1:5433

Open dashboard

<http://localhost:8000/>

Take a screenshot of the browser to compare with the new version

Kill the Skaffold by pressing Ctrl+C

Test with the latest Kubeshark

Install the latest kubeshark system-wide

<https://docs.kubeshark.co/en/install>

```sh
rm /tmp/str-4443/kubeshark
sh <(curl -Ls https://kubeshark.co/install)
kubeshark version
```

Switch the CAST main branch

```sh
cd /tmp/str-4443/cast
git checkout main
git checkout str-4443-kubeshark-38
```

Verify the we have the correct version of Kubeshark

```sh
kubeshark version # >= 38.5
```

Clean up everything

```sh
kubeshark --set kube.context=docker-desktop clean
skaffold delete --kube-context docker-desktop # ignore any errors about missing releases
kubectl --context docker-desktop delete ns cast
kubectl --context docker-desktop delete ns kubeshark
```

Start the test Skaffold

```sh
skaffold run --platform=linux/amd64 --port-forward --kube-context docker-desktop
```

Wait for the following log messages

    Port forwarding service/cast-postgresql in namespace cast, remote port 5432 -> http://127.0.0.1:5432
    Port forwarding service/cast-service in namespace cast, remote port 80 -> http://127.0.0.1:8000
    Port forwarding service/httpbin in namespace cast, remote port 80 -> http://127.0.0.1:8080
    Port forwarding service/cast-postgresql-hl in namespace cast, remote port 5432 -> http://127.0.0.1:5433

Open dashboard

<http://localhost:8000/>

Compare what you see to the screenshot you made with the old version

