### PR TITLE
STR-4604: Pin Kubeshark version against our own images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ clean:
 
 # remove cast deployment resources
 cast-clean:
-	kubectl delete pvc data-cast-postgresql-0 -n cast
 	kubectl delete ns cast
 	kubeshark clean
 

--- a/cmd/castRunner.go
+++ b/cmd/castRunner.go
@@ -18,21 +18,16 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
-	"github.com/kirsle/configdir"
 	helm "github.com/mittwald/go-helm-client"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	"helm.sh/helm/v3/pkg/repo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,11 +38,9 @@ import (
 	"k8s.io/client-go/transport/spdy"
 )
 
-const kubesharkVersion string = "38.5" // supported Kubeshark version
-
 // cast runs kubeshark tap and deploys CAST. On exit, it will clean up
 // CAST and kubeshark resources.
-func cast(namespace string, port string, kubeConfigPath string, kubeContext string, testMode bool) {
+func cast(namespace string, port string, kubeConfigPath string, kubeContext string, noDownload, testMode bool) {
 	log.Info("Namespace to be analyzed: ", namespace)
 
 	// trap Ctrl+C and call cancel on the context
@@ -55,27 +48,15 @@ func cast(namespace string, port string, kubeConfigPath string, kubeContext stri
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Check for Kubeshark
-
-	kubesharkPath := "kubeshark" // path to kubeshark binary
-	ksOutput, err := exec.Command(kubesharkPath, "version").CombinedOutput()
-
-	// If Kubeshark is not in $PATH or is not kubesharkVersion, download binary into UserConfigDir
-	if err != nil || !strings.Contains(string(ksOutput), kubesharkVersion) {
-		log.Infof("Kubeshark v%s is not installed. Installing Kubeshark v%s in app config directory.", kubesharkVersion, kubesharkVersion)
-		kubesharkPath, err = downloadKubeshark(ctx)
-		if err != nil {
-			log.WithError(err).Errorf("Failed to install Kubeshark v%s.", kubesharkVersion)
-			return
-		}
-	}
-
-	log.Infof("Kubeshark v%s installation confirmed.", kubesharkVersion)
+	// Get (or download) Kubeshark
+	kubesharkPath := getKubesharkCmd(ctx, noDownload)
+	// Ensure config file exists, and get its path:
+	kubesharkConfig := ensureKubesharkConfigfile()
 
 	// Create helm client
 
 	var kubeConfig []byte
-	kubeConfig, err = os.ReadFile(kubeConfigPath)
+	kubeConfig, err := os.ReadFile(kubeConfigPath)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{"kubeconfig": kubeConfigPath}).Error("Error reading kubeconfig.")
 		return
@@ -121,7 +102,7 @@ func cast(namespace string, port string, kubeConfigPath string, kubeContext stri
 
 	cmdConfig := fmt.Sprintf("kube-config-path=%s", kubeConfigPath)
 	cmdContext := fmt.Sprintf("kube-context=%s", kubeContext)
-	ksCmd := exec.CommandContext(ctx, kubesharkPath, "tap", "-n", namespace, "--set", "headless=true", "--set", cmdConfig, "--set", cmdContext)
+	ksCmd := exec.CommandContext(ctx, kubesharkPath, "tap", "--configpath", kubesharkConfig, "-n", namespace, "--set", "headless=true", "--set", cmdConfig, "--set", cmdContext)
 
 	err = ksCmd.Start()
 	if err != nil {
@@ -155,7 +136,7 @@ func cast(namespace string, port string, kubeConfigPath string, kubeContext stri
 
 	// Install CAST chart release.
 
-	defer castCleanup(helmClient, clientset, kubesharkPath)
+	defer castCleanup(helmClient, clientset, noDownload)
 
 	go func(ctx context.Context) {
 		select {
@@ -251,68 +232,6 @@ func deployCast(ctx context.Context, helmClient helm.Client, clientset *kubernet
 	}
 }
 
-// downloadKubeshark downloads the Kubeshark binary to the UserConfigDir and returns the path to the binary.
-func downloadKubeshark(ctx context.Context) (string, error) {
-	osArch := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
-	available := []string{"darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64"}
-	if !slices.Contains(available, osArch) {
-		return "", fmt.Errorf("Unsupported OS or architecture: %s. For more details, visit https://github.com/kubeshark/kubeshark/releases/tag/%s.", osArch, kubesharkVersion)
-	}
-
-	// download binary to config directory
-	ksDownload := fmt.Sprintf("https://github.com/kubeshark/kubeshark/releases/download/%s/kubeshark_%s", kubesharkVersion, osArch)
-
-	configPath := configdir.LocalConfig("cast")
-	err := configdir.MakePath(configPath) // Ensure it exists.
-	if err != nil {
-		return "", fmt.Errorf("Error creating private config directory: %v", err)
-	}
-
-	kubesharkPath := filepath.Join(configPath, "kubeshark")
-
-	// check if Kubeshark has already been downloaded to UserConfigDir.
-	ksOutput, err := exec.Command(kubesharkPath, "version").CombinedOutput()
-	if err == nil {
-		if strings.Contains(string(ksOutput), kubesharkVersion) {
-			log.Infof("Kubeshark v%s already exists in %s.", kubesharkVersion, configPath)
-			return kubesharkPath, nil
-		}
-		log.Infof("Incorrect Kubeshark version found in %s. Deleting and installing v%s.", configPath, kubesharkVersion)
-		os.Remove(kubesharkPath)
-	}
-
-	ksOut, err := os.Create(kubesharkPath)
-	if err != nil {
-		return "", fmt.Errorf("Error creating file to download Kubeshark into:%v", err)
-	}
-	defer ksOut.Close()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ksDownload, nil)
-	if err != nil {
-		return "", fmt.Errorf("Error creating kubeshark download GET request: %v", err)
-	}
-
-	client := http.DefaultClient
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("Error downloading release from %s: %v", ksDownload, err)
-	}
-
-	defer resp.Body.Close()
-	_, err = io.Copy(ksOut, resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("Error copying response into Kubeshark file: %v", err)
-	}
-	err = os.Chmod(kubesharkPath, 0755)
-	if err != nil {
-		return "", fmt.Errorf("Error making Kubeshark binary executable: %v", err)
-	}
-
-	log.Infof("Kubeshark v%s successfully installed at %s", kubesharkVersion, kubesharkPath)
-	return kubesharkPath, nil
-
-}
-
 // portForward port forwards from port 3000 on the pod to 3000 on localhost
 func portForward(pod v1.Pod, port string, config *rest.Config, stopCh <-chan struct{}, readyCh chan struct{}) error {
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", "cast", pod.Name)
@@ -332,8 +251,10 @@ func portForward(pod v1.Pod, port string, config *rest.Config, stopCh <-chan str
 }
 
 // castCleanup removes CAST and Kubeshark resources
-func castCleanup(helmClient helm.Client, clientset *kubernetes.Clientset, kubesharkPath string) {
+func castCleanup(helmClient helm.Client, clientset *kubernetes.Clientset, noDownload bool) {
 	log.Info("Removing CAST resources.")
+	kubesharkPath := getKubesharkCmd(context.TODO(), noDownload)
+	kubesharkConfig := ensureKubesharkConfigfile()
 
 	// Delete CAST release
 	err := helmClient.UninstallReleaseByName("cast")
@@ -350,7 +271,7 @@ func castCleanup(helmClient helm.Client, clientset *kubernetes.Clientset, kubesh
 
 	// Remove Kubeshark resources
 	log.Info("Removing Kubeshark resources.")
-	err = exec.Command(kubesharkPath, "clean").Run()
+	err = exec.Command(kubesharkPath, "clean", "--configpath", kubesharkConfig).Run()
 	if err != nil {
 		log.WithError(err).Error("Error running 'kubeshark clean'. ")
 		return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,13 +31,14 @@ var port string = "3000"
 var namespace string
 var kubeConfig string = filepath.Join(homedir.HomeDir(), ".kube", "config")
 var testMode bool
+var noDownload bool
 
 var rootCmd = &cobra.Command{
-	Use:   "cast -n [namespace]",
+	Use:   "cast [OPTIONS]",
 	Short: "CAST captures the network traffic in your namespace",
 	Long:  "CAST: A tool to evaluate security concerns surrounding API Communication and Authentication. For more info: https://github.com/corshatech/cast. cast captures the network traffic in your namespace",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cast(namespace, port, kubeConfig, kubeContext, testMode)
+		cast(namespace, port, kubeConfig, kubeContext, noDownload, testMode)
 		return nil
 	},
 }
@@ -48,6 +49,7 @@ func init() {
 	rootCmd.Flags().StringVar(&kubeConfig, "kube-config", kubeConfig, "Path to kube config file.")
 	rootCmd.Flags().StringVar(&kubeContext, "kube-context", kubeContext, `Kube context to deploy CAST into. (default "current-context")`)
 	rootCmd.Flags().BoolVar(&testMode, "test", false, `Enables local testing mode.`)
+	rootCmd.Flags().BoolVar(&noDownload, "no-download", false, "Do not automatically download and install Kubeshark.")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/userdir.go
+++ b/cmd/userdir.go
@@ -155,7 +155,7 @@ func ensureKubesharkConfigfile() string {
 
 	log.WithField("file", castConfigfile).Debug("Writing default config file.")
 	// 0666 is file permission `rw-rw-rw-`
-	err = os.WriteFile(castConfigfile, []byte(defaultKubesharkConfig), 0666)
+	err = os.WriteFile(castConfigfile, []byte(defaultKubesharkConfig), 0600)
 	if err != nil {
 		log.WithError(err).WithField("file", castConfigfile).Fatal("Unable to write config file.")
 	}

--- a/cmd/userdir.go
+++ b/cmd/userdir.go
@@ -1,0 +1,222 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/kirsle/configdir"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
+)
+
+var kubesharkCmdDefault string = "kubeshark"
+
+func init() {
+	if runtime.GOOS == "windows" {
+		kubesharkCmdDefault = "kubeshark.exe"
+	}
+}
+
+const kubesharkVersion string = "38.5" // supported Kubeshark version
+
+// The default Kubeshark Config, customized for CAST.
+// This is almost, very nearly, the same thing as the default Kubeshark
+// configfile output by `kubeshark config`, except we've specified the
+// specific, supported docker image that works with CAST.
+const defaultKubesharkConfig string = `
+tap:
+    docker:
+        registry: ghcr.io/corshatech/kubeshark-
+        tag: "corshav38.5"
+        imagepullpolicy: Always
+        imagepullsecrets: []
+    proxy:
+        worker:
+            port: 8897
+            srvport: 8897
+        hub:
+            port: 8898
+            srvport: 80
+        front:
+            port: 8899
+            srvport: 80
+        host: 127.0.0.1
+    regex: .*
+    namespaces: []
+    allnamespaces: false
+    storagelimit: 200MB
+    dryrun: false
+    pcap: ""
+    resources:
+        worker:
+            cpu-limit: 750m
+            memory-limit: 1Gi
+            cpu-requests: 50m
+            memory-requests: 50Mi
+        hub:
+            cpu-limit: 750m
+            memory-limit: 1Gi
+            cpu-requests: 50m
+            memory-requests: 50Mi
+    servicemesh: true
+    tls: true
+    packetcapture: libpcap
+    debug: false
+logs:
+    file: ""
+selfnamespace: kubeshark
+dumplogs: false
+headless: true
+`
+
+func getConfigDir() string {
+	directory := configdir.LocalConfig("cast")
+	err := configdir.MakePath(directory)
+	if err != nil {
+		log.WithError(err).
+			WithField("configdir", directory).
+			Fatal("Unable to ensure access to CAST config directory.")
+	}
+	return directory
+}
+
+// getKubesharkCommand returns the preferred absolute path of the Kubeshark
+// binary CAST should be using. In addition, it calls ensureKubesharkVersion()
+// which prints a user-facing warning if the Kubeshark in use doesn't match
+// our preferred version.
+//
+//  1. If Kubeshark is on the path, use that Kubeshark.
+//  2. Otherwise, try to use the Kubeshark from our config directory.
+//  3. If neither (1) nor (2) already exist, download Kubeshark locally
+//     into the config dir, then use that.
+func getKubesharkCmd(ctx context.Context, noDownload bool) string {
+	kubesharkPath, err := exec.LookPath(kubesharkCmdDefault)
+	if err == nil {
+		ensureKubesharkVersion(kubesharkPath)
+		return kubesharkPath
+	}
+
+	// An error is acceptable since it means kubeshark is
+	// not on the system path, so we just go ahead with
+	// downloading and installing our own copy.
+	kubesharkPath, err = downloadKubeshark(ctx, noDownload)
+	if err != nil {
+		log.WithError(err).Fatal("Unable to find or install Kubeshark cli.")
+	}
+	ensureKubesharkVersion(kubesharkPath)
+	return kubesharkPath
+}
+
+// Tests the kubeshark cli version with the version verb.
+// Panics if calling the CLI doesn't succeed, since this is a problem with
+// exec() and we need exec() to work.
+//
+// Otherwise, if the detected version appears to be unsupported, we log a
+// warning but otherwise permit this.
+func ensureKubesharkVersion(kubesharkPath string) {
+	ksOutput, err := exec.Command(kubesharkPath, "version").CombinedOutput()
+	if err != nil {
+		log.WithError(err).WithField("kubeshark", kubesharkPath).Fatalf("Unable to invoke Kubeshark")
+	}
+
+	if !strings.Contains(string(ksOutput), kubesharkVersion) {
+		log.Warnf("Warning: CAST is built to support Kubeshark version %s, and you're using version %s.", kubesharkVersion, ksOutput)
+		log.Warn("Some commands may not work as expected.")
+	}
+}
+
+func ensureKubesharkConfigfile() string {
+	configdir := getConfigDir()
+	castConfigfile := path.Join(configdir, "kubeshark-config.yaml")
+
+	info, err := os.Stat(castConfigfile)
+	// If the file can be statted,
+	// and is regular,
+	// and can be read (`& modebits with mask 0444` is nonzero)
+	// then simply use it:
+	if err == nil && info.Mode().IsRegular() && info.Mode()&0444 != 0 {
+		return castConfigfile
+	}
+
+	// if any error other than NotExists (for which we'll write the file)
+	// end with Fatal
+	if !errors.Is(err, fs.ErrNotExist) {
+		log.WithError(err).WithField("file", castConfigfile).Fatal("Unable to read config file.")
+	}
+
+	log.WithField("file", castConfigfile).Debug("Writing default config file.")
+	// 0666 is file permission `rw-rw-rw-`
+	err = os.WriteFile(castConfigfile, []byte(defaultKubesharkConfig), 0666)
+	if err != nil {
+		log.WithError(err).WithField("file", castConfigfile).Fatal("Unable to write config file.")
+	}
+	return castConfigfile
+}
+
+// downloadKubeshark downloads the Kubeshark binary to the UserConfigDir and returns the path to the binary.
+func downloadKubeshark(ctx context.Context, noDownload bool) (string, error) {
+	configdir := getConfigDir()
+	castKubeshark := path.Join(configdir, kubesharkCmdDefault)
+
+	info, err := os.Stat(castKubeshark)
+	// if there is no error when statting,
+	// AND the file is regular,
+	// AND the file is executable (`& modebits with mask 0111` is nonzero)
+	// then we accept that this is the kubeshark executable:
+	if err == nil && info.Mode().IsRegular() && info.Mode()&0111 != 0 {
+		return castKubeshark, nil
+	}
+
+	// bail: attempt to download and install castKubeshark for the user.
+	if noDownload {
+		return "", fmt.Errorf("unable to locate kubeshark, and noDownload is set, so not installing automatically")
+	}
+
+	// First, figure out download URL.
+
+	osArch := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
+	available := []string{"darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64"}
+	if !slices.Contains(available, osArch) {
+		return "", fmt.Errorf("unsupported OS or architecture: %s. For more details, visit https://github.com/kubeshark/kubeshark/releases/tag/%s", osArch, kubesharkVersion)
+	}
+
+	ksDownload := fmt.Sprintf("https://github.com/kubeshark/kubeshark/releases/download/%s/kubeshark_%s", kubesharkVersion, osArch)
+
+	log.WithFields(log.Fields{
+		"url":         ksDownload,
+		"castDataDir": configdir,
+	}).Info("Unable to locate Kubeshark, installing locally", ksDownload)
+
+	ksOut, err := os.Create(castKubeshark)
+	if err != nil {
+		return "", fmt.Errorf("error creating file \"%s\"", castKubeshark)
+	}
+	defer ksOut.Close()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ksDownload, nil)
+	if err != nil {
+		return "", fmt.Errorf("error downloading release from %s %v", ksDownload, err)
+	}
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error downloading release from %s %v", ksDownload, err)
+	}
+	defer response.Body.Close()
+	_, err = io.Copy(ksOut, response.Body)
+	if err != nil {
+		return "", fmt.Errorf("error downloading release from %s %v", ksDownload, err)
+	}
+
+	log.WithField("file", castKubeshark).Infof("Installed Kubeshark successfully")
+	return castKubeshark, nil
+}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -134,8 +134,7 @@ func main() {
 		retry.Attempts(retryAttempts),
 		retry.Delay(retryDelay),
 		retry.OnRetry(func(n uint, err error) {
-			log.Infof("Error connecting to postgres database. Retrying in %vs", retryDelay)
-			time.Sleep(retryDelay)
+			log.Infof("Error connecting to postgres database. Retrying in %v", retryDelay)
 		}),
 	)
 	if err != nil {
@@ -154,8 +153,7 @@ func main() {
 		retry.Attempts(5),
 		retry.Delay(retryDelay),
 		retry.OnRetry(func(n uint, err error) {
-			log.Infof("Unable to reach postgres database. Retrying in %vs", 5)
-			time.Sleep(retryDelay)
+			log.Infof("Unable to reach postgres database. Retrying in %v", retryDelay)
 		}),
 	)
 	if err != nil {
@@ -171,10 +169,9 @@ func main() {
 			return err
 		},
 		retry.Attempts(retryAttempts),
-		retry.Delay(retryDelay*time.Second),
+		retry.Delay(retryDelay),
 		retry.OnRetry(func(n uint, err error) {
-			log.Infof("Error connecting to kubeshark websocket. Retrying in %vs", retryDelay)
-			time.Sleep(retryDelay)
+			log.Infof("Error connecting to kubeshark websocket. Retrying in %v", retryDelay)
 		}),
 	)
 	if err != nil {
@@ -222,8 +219,7 @@ func main() {
 		retry.Attempts(retryAttempts),
 		retry.Delay(retryDelay),
 		retry.OnRetry(func(n uint, err error) {
-			log.Infof("Error exporting records. Retrying in %vs", retryDelay)
-			time.Sleep(retryDelay)
+			log.Infof("Error exporting records. Retrying in %v", retryDelay)
 		}),
 	)
 	if err != nil {
@@ -314,8 +310,7 @@ func writeRecords(pgConnection *sql.DB, ksURL string, ksConnection *websocket.Co
 		retry.Attempts(retryAttempts),
 		retry.Delay(retryDelay),
 		retry.OnRetry(func(n uint, err error) {
-			log.WithError(err).Infof("Error inserting entry into postgres database. Retrying in %vs.", retryDelay)
-			time.Sleep(retryDelay)
+			log.WithError(err).Infof("Error inserting entry into postgres database. Retrying in %v", retryDelay)
 		}),
 	)
 

--- a/plugins/kubesec/cast_db.go
+++ b/plugins/kubesec/cast_db.go
@@ -64,7 +64,7 @@ func init() {
 		func() error {
 			return pgConnection.Ping()
 		},
-		retry.Attempts(5),
+		retry.Attempts(retryAttempts),
 		retry.Delay(retryDelay),
 		retry.OnRetry(func(n uint, err error) {
 			log.Infof("Unable to reach postgres database. Retrying in %vs", retryDelay)

--- a/scripts/kubeshark-tap-with-data.sh
+++ b/scripts/kubeshark-tap-with-data.sh
@@ -32,7 +32,14 @@ fi
 kubectl --context="${CONTEXT}" delete ns kubeshark --wait=true || true
 
 # kubeshark tap
-nohup kubeshark --set kube.context="${CONTEXT}" tap -n cast "(httpbin*)" --set headless=true > kubeshark.out 2> kubeshark.err < /dev/null &
+nohup kubeshark \
+    --set kube.context="${CONTEXT}" \
+    tap \
+    -n cast "(httpbin*)" \
+    --set headless=true \
+    --set tap.docker.registry="ghcr.io/corshatech/kubeshark-" \
+    --set tap.docker.tag="corshav38.5"\
+    > kubeshark.out 2> kubeshark.err < /dev/null &
 
 
 # Waiting for collector pod successfully connect to postgres and kubeshark


### PR DESCRIPTION
Before you submit your PR, make sure you check each of the following:

1. [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and signed the [Contributor License Agreement](./CLA.md).
2. [x] My code is clean and ready-to-PR, including being free of lint errors and dead code
3. [x] I have **tested** my change / code and am confident that it works
4. [x] I have filled in the template below completely and accurately
##### Changelog

- Kubeshark commands in the CLI and our scripts explicitly use our own hosted Kubeshark images, pinned to a particular version.

##### Testing

- Tested locally by deploying CAST and inspecting the deployed pods for kubeshark workloads. Each pod is now using our (corshatech/) namespaced images

##### Unit Tests

N/A

