### PR TITLE
Cast v0.1.0 rc.4

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -21,6 +21,9 @@ jobs:
           - dockerfile: ./ui/Dockerfile
             image: ghcr.io/corshatech/cast/ui
             context: ui
+          - dockerfile: ./plugins/kubesec/Dockerfile
+            image: ghcr.io/corshatech/cast/plugins/kubesec
+            context: ./plugins/kubesec
     permissions:
       contents: read
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,6 @@ config/
 
 coverage.out
 /docs/badge.svg
-/build/package/cast
+/build/
 /.log/
 /.scratch/

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ images:
 cast:
 	$(GO) build -gcflags="all=-N -l" -o build/package/cast cast.go
 
+all-platforms-cast:
+	GOOS=linux GOARCH=arm64 $(GO) build -gcflags="all=-N -l" -o build/cast_linux_arm64
+	GOOS=darwin GOARCH=arm64 $(GO) build -gcflags="all=-N -l" -o build/cast_darwin_arm64
+	GOOS=linux GOARCH=amd64 $(GO) build -gcflags="all=-N -l" -o build/cast_linux_amd64
+	GOOS=darwin GOARCH=amd64 $(GO) build -gcflags="all=-N -l" -o build/cast_darwin_amd64
+
 tidy:
 	$(GO) mod tidy
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations.
 
-GO = GOPRIVATE=github.com/corshatech/* GO111MODULE=on go
-
 VERSION ?= "0.1.0"
 
 all: tidy test lint image markdown
@@ -18,7 +16,7 @@ all: tidy test lint image markdown
 test: test-go test-ui
 
 test-go:
-	$(GO) test -coverprofile=coverage.out ./...
+	go test -coverprofile=coverage.out ./...
 
 test-ui:
 	cd ui && npm ci && npm run "test:ci"
@@ -27,16 +25,16 @@ images:
 	skaffold build -t ${VERSION} --default-repo=ghcr.io/corshatech/cast
 
 cast:
-	$(GO) build -gcflags="all=-N -l" -o build/package/cast cast.go
+	go build -gcflags="all=-N -l" -o build/package/cast cast.go
 
 all-platforms-cast:
-	GOOS=linux GOARCH=arm64 $(GO) build -gcflags="all=-N -l" -o build/cast_linux_arm64
-	GOOS=darwin GOARCH=arm64 $(GO) build -gcflags="all=-N -l" -o build/cast_darwin_arm64
-	GOOS=linux GOARCH=amd64 $(GO) build -gcflags="all=-N -l" -o build/cast_linux_amd64
-	GOOS=darwin GOARCH=amd64 $(GO) build -gcflags="all=-N -l" -o build/cast_darwin_amd64
+	GOOS=linux GOARCH=arm64 go build -gcflags="all=-N -l" -o build/cast_linux_arm64
+	GOOS=darwin GOARCH=arm64 go build -gcflags="all=-N -l" -o build/cast_darwin_arm64
+	GOOS=linux GOARCH=amd64 go build -gcflags="all=-N -l" -o build/cast_linux_amd64
+	GOOS=darwin GOARCH=amd64 go build -gcflags="all=-N -l" -o build/cast_darwin_amd64
 
 tidy:
-	$(GO) mod tidy
+	go mod tidy
 
 lint: lint-ui lint-go lint-helm lint-markdown
 
@@ -59,7 +57,7 @@ lint-markdown:
 	./ui/node_modules/.bin/markdownlint-cli2-config .markdownlint.yaml "**/*.md" "#ui/node_modules" "#.github"
 
 clean:
-	$(GO) clean ./...
+	go clean ./...
 	$(RM) -rf build
 
 # remove cast deployment resources

--- a/cmd/castRunner.go
+++ b/cmd/castRunner.go
@@ -143,7 +143,7 @@ func cast(namespace string, port string, kubeConfigPath string, kubeContext stri
 		case <-ctx.Done():
 			return
 		default:
-			deployCast(ctx, helmClient, clientset, config, port, testMode)
+			deployCast(ctx, helmClient, clientset, config, port, castChartVersion, testMode)
 		}
 	}(ctx)
 
@@ -161,7 +161,7 @@ func cast(namespace string, port string, kubeConfigPath string, kubeContext stri
 }
 
 // deployCast is a helper function that deploys the CAST helm chart.
-func deployCast(ctx context.Context, helmClient helm.Client, clientset *kubernetes.Clientset, config *rest.Config, port string, testMode bool) {
+func deployCast(ctx context.Context, helmClient helm.Client, clientset *kubernetes.Clientset, config *rest.Config, port, version string, testMode bool) {
 
 	chartName := "corshatech/cast"
 	// if testMode=true, use local chart instead of pulling from repo
@@ -172,6 +172,7 @@ func deployCast(ctx context.Context, helmClient helm.Client, clientset *kubernet
 
 	chartSpec := helm.ChartSpec{
 		ReleaseName:     "cast",
+		Version:         version,
 		CreateNamespace: true,
 		ChartName:       chartName,
 		Namespace:       "cast",

--- a/cmd/castRunner.go
+++ b/cmd/castRunner.go
@@ -178,7 +178,7 @@ func deployCast(ctx context.Context, helmClient helm.Client, clientset *kubernet
 		Namespace:       "cast",
 		UpgradeCRDs:     true,
 		Wait:            true,
-		Timeout:         2 * time.Minute, // postgres pod can take >30s to be ready.
+		Timeout:         10 * time.Minute, // postgres pod can take >30s to be ready.
 	}
 	if _, err := helmClient.InstallOrUpgradeChart(ctx, &chartSpec, nil); err != nil {
 		handleError(ctx, "Error installing CAST helm chart.", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ var (
 var port string = "3000"
 var namespace string
 var kubeConfig string = filepath.Join(homedir.HomeDir(), ".kube", "config")
-var castChartVersion string = ""
+var castChartVersion string
 var testMode bool
 var noDownload bool
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ var (
 var port string = "3000"
 var namespace string
 var kubeConfig string = filepath.Join(homedir.HomeDir(), ".kube", "config")
+var castChartVersion string = ""
 var testMode bool
 var noDownload bool
 
@@ -46,6 +47,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.Flags().StringVarP(&namespace, "namespace", "n", "all", "The namespace to analyze.")
 	rootCmd.Flags().StringVarP(&port, "port", "p", "3000", "The port the CAST UI will be available on.")
+	rootCmd.Flags().StringVar(&castChartVersion, "use-version", "", "The version of the CAST Helm Chart to deploy. If empty, will use the latest version.")
 	rootCmd.Flags().StringVar(&kubeConfig, "kube-config", kubeConfig, "Path to kube config file.")
 	rootCmd.Flags().StringVar(&kubeContext, "kube-context", kubeContext, `Kube context to deploy CAST into. (default "current-context")`)
 	rootCmd.Flags().BoolVar(&testMode, "test", false, `Enables local testing mode.`)

--- a/cmd/userdir.go
+++ b/cmd/userdir.go
@@ -196,7 +196,7 @@ func downloadKubeshark(ctx context.Context, noDownload bool) (string, error) {
 		"castDataDir": configdir,
 	}).Info("Unable to locate Kubeshark, installing locally", ksDownload)
 
-	ksOut, err := os.Create(castKubeshark)
+	ksOut, err := os.OpenFile(castKubeshark, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0500)
 	if err != nil {
 		return "", fmt.Errorf("error creating file \"%s\"", castKubeshark)
 	}


### PR DESCRIPTION
RC4 contains the following changes from RC1:
- Fixes STR-4604 pinned deployed version of kubeshark
- Fixes STR-4619 write downloaded kubeshark version with +x
- Fixes STR-4622 publish plugin/kubesec container image when creating releases

