### PR TITLE
STR-4589: Convert internal errors to missing data.

### DIFF
--- a/ui/lib/analysis/expired-jwt.ts
+++ b/ui/lib/analysis/expired-jwt.ts
@@ -118,8 +118,8 @@ export async function runnerPure(
   };
 }
 
-export async function runner(): Promise<Analysis> {
+export async function runner(): Promise<Analysis[]> {
   const queryFunction = async () => (await conn.query(query, [])).rows;
 
-  return runnerPure(queryFunction);
+  return [await runnerPure(queryFunction)];
 }

--- a/ui/lib/analysis/kubesec.ts
+++ b/ui/lib/analysis/kubesec.ts
@@ -53,12 +53,10 @@ async function query(): Promise<KubesecFinding[]> {
   return rows.map(x => kubesecRowToFinding(KubesecSQLRow.parse(x)));
 }
 
-export async function kubesec(): Promise<AnalysisOf<KubesecFinding>> {
-  // TODO: What to do when Kubesec plugin hasn't run yet...?
-  // That's not the same thing as `findings: []`
+export async function kubesec(): Promise<AnalysisOf<KubesecFinding>[]> {
   const findings = await query();
   const severity = findings.find(({severity}) => severity === 'critical') ? 'critical' : 'none';
-  return {
+  return [{
     id: 'cast-kubesec',
     title: 'Kubesec',
     description: 'The Kubesec plugin scans your running Kubernetes cluster with kubesec.io, and reports the results here.',
@@ -66,5 +64,5 @@ export async function kubesec(): Promise<AnalysisOf<KubesecFinding>> {
     weaknessLink: 'https://kubesec.io/',
     severity,
     findings,
-  };
+  }];
 }

--- a/ui/lib/analysis/pass_in_url.ts
+++ b/ui/lib/analysis/pass_in_url.ts
@@ -98,7 +98,7 @@ export async function runnerPure(query: QueryFunction): Promise<Analysis> {
   };
 }
 
-export async function runner(): Promise<Analysis> {
+export async function runner(): Promise<Analysis[]> {
   const queryFunction = async () => (await conn.query(query, [])).rows;
-  return runnerPure(queryFunction);
+  return [await runnerPure(queryFunction)];
 }

--- a/ui/lib/analysis/reused-authentication.ts
+++ b/ui/lib/analysis/reused-authentication.ts
@@ -156,7 +156,7 @@ export async function runnerPure(query: QueryFunction): Promise<Analysis> {
   };
 }
 
-export async function runner(): Promise<Analysis> {
+export async function runner(): Promise<Analysis[]> {
   const queryFunction = async () => (await conn.query(query, [])).rows;
-  return runnerPure(queryFunction);
+  return [await runnerPure(queryFunction)];
 }

--- a/ui/lib/analysis/useOfBasicAuth.ts
+++ b/ui/lib/analysis/useOfBasicAuth.ts
@@ -71,8 +71,8 @@ export async function runnerPure(query: () => Promise<Row[]>): Promise<Analysis>
   };
 }
 
-export async function useOfBasicAuth(): Promise<Analysis> {
+export async function useOfBasicAuth(): Promise<Analysis[]> {
   const queryFunction = async () => (await conn.query(query, [])).rows;
 
-  return runnerPure(queryFunction);
+  return [await runnerPure(queryFunction)];
 }


### PR DESCRIPTION
Presently, internal server errors make the entire dashboard crash. As an interim solution, this simple refactor allows the CAST backend to omit analyses which fail, logging an error and producing no data for those analyses.

In the future, we should make this system even more robust, and do more than simply logging such failures:
- It should be possible to return Analysis metadata even for failed analyses.
- It should be possible to return partially-completed Analyses (i.e. a mix of data and errors)
- We should return to the frontend some data indicating errors encountered, and render the errors somewhere, so the user can see when internal errors are occurring without resorting to opening logs.
