### PR TITLE
[CAST-135] Upgrade Kubeshark to 41.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ CAST uses [Kubeshark](https://kubeshark.co/) to collect traffic. If you don't
 have Kubeshark already, CAST will download and install it for you as part
 of deployment.
 
-We currently only support Kubeshark version v38.5. If you would like to install
+We currently only support Kubeshark version v41.6. If you would like to install
 Kubeshark system-wide, you can follow the installation instructions
 [found in Kubeshark's documentation](https://docs.kubeshark.co/en/install).
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ var (
 
 var port string = "3000"
 var namespace string
-var kubeConfig string = filepath.Join(homedir.HomeDir(), ".kube", "config")
+var kubeConfig string
 var castChartVersion string
 var testMode bool
 var noDownload bool
@@ -45,11 +45,11 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&namespace, "namespace", "n", "all", "The namespace to analyze.")
+	rootCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "The namespace to analyze.")
 	rootCmd.Flags().StringVarP(&port, "port", "p", "3000", "The port the CAST UI will be available on.")
 	rootCmd.Flags().StringVar(&castChartVersion, "use-version", "", "The version of the CAST Helm Chart to deploy. If empty, will use the latest version.")
-	rootCmd.Flags().StringVar(&kubeConfig, "kube-config", kubeConfig, "Path to kube config file.")
-	rootCmd.Flags().StringVar(&kubeContext, "kube-context", kubeContext, `Kube context to deploy CAST into. (default "current-context")`)
+	rootCmd.Flags().StringVar(&kubeConfig, "kube-config", filepath.Join(homedir.HomeDir(), ".kube", "config"), "Path to kube config file.")
+	rootCmd.Flags().StringVar(&kubeContext, "kube-context", "", `Kube context to deploy CAST into. (default "current-context")`)
 	rootCmd.Flags().BoolVar(&testMode, "test", false, `Enables local testing mode.`)
 	rootCmd.Flags().BoolVar(&noDownload, "no-download", false, "Do not automatically download and install Kubeshark.")
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -87,8 +87,9 @@ type TrafficItem struct {
 }
 
 type Message struct {
-	Id    string       `json:"id"`
-	Proto MessageProto `json:"proto"`
+	Id      string       `json:"id"`
+	Context string       `json:"context"`
+	Proto   MessageProto `json:"proto"`
 }
 
 type MessageProto struct {

--- a/collector/internal/test/kubeshark/service.go
+++ b/collector/internal/test/kubeshark/service.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// kubeshark implements a test service that mimics the Kubeshark 38 Hub API
+// kubeshark implements a test service that mimics the Kubeshark 41 Hub API
 package kubeshark
 
 import (

--- a/collector/item_analysis.go
+++ b/collector/item_analysis.go
@@ -127,7 +127,7 @@ outer:
 
 func analysisWorker(ctx *workerContext) {
 	for message := range ctx.Queue {
-		itemUrl := fmt.Sprintf("%s/item/%s?q=", ctx.KsHubUrl, message.Id)
+		itemUrl := fmt.Sprintf("%s/item/%s?c=%s&q=", ctx.KsHubUrl, message.Id, message.Context)
 		requestContext, cancel := context.WithDeadline(context.Background(), deadline(1*time.Minute))
 
 		trafficItemJson, err := fetchItem(requestContext, itemUrl)
@@ -281,7 +281,7 @@ func handleTrafficItem(trafficItemJson []byte, trafficItem *TrafficItem) ([]byte
 		return nil, nil, err
 	}
 
-	// In Kubeshark 38 the trafficItem JSON contains the data and a
+	// In Kubeshark 41 the trafficItem JSON contains the data and a
 	// string version of data in a key called representation. This
 	// caused the JWT detection to match each JWT string twice
 	originalTrafficDataJson, err := json.Marshal(trafficItemMap["data"])

--- a/k8s/helm/cast/Chart.yaml
+++ b/k8s/helm/cast/Chart.yaml
@@ -26,13 +26,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: "0.0.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.0.0"
 
 dependencies:
   - name: postgresql

--- a/k8s/helm/cast/values.yaml
+++ b/k8s/helm/cast/values.yaml
@@ -76,7 +76,7 @@ plugins:
 collector:
   env:
     PGPORT: "5432"
-    KUBESHARK_HUB_URL: "http://kubeshark-hub.kubeshark.svc.cluster.local"
+    KUBESHARK_HUB_URL: "http://kubeshark-hub.default.svc.cluster.local"
 
   image:
     tag: ""

--- a/scripts/kubeshark-tap-with-data.sh
+++ b/scripts/kubeshark-tap-with-data.sh
@@ -22,14 +22,14 @@ if ! [ -x "$(command -v kubeshark)" ]; then
 fi
 
 KUBESHARK_VERSION="$(kubeshark version 2>&1)"
-if [ "$KUBESHARK_VERSION" != "38.5" ]; then
+if [ "$KUBESHARK_VERSION" != "41.6" ]; then
     kubeshark version
-    echo "ERROR: incorrect version of kubeshark installed, please install 38.5"
+    echo "ERROR: incorrect version of kubeshark installed, please install 41.6"
     exit 1
 fi
 
 # clean up any existing kubeshark install
-kubectl --context="${CONTEXT}" delete ns kubeshark --wait=true || true
+kubeshark clean --set kube.context="${CONTEXT}" || true
 
 # kubeshark tap
 nohup kubeshark \
@@ -37,8 +37,8 @@ nohup kubeshark \
     tap \
     -n cast "(httpbin*)" \
     --set headless=true \
-    --set tap.docker.registry="ghcr.io/corshatech/kubeshark-" \
-    --set tap.docker.tag="corshav38.5"\
+    --set tap.docker.registry="ghcr.io/corshatech/kubeshark" \
+    --set tap.docker.tag="corshav41.6"\
     > kubeshark.out 2> kubeshark.err < /dev/null &
 
 


### PR DESCRIPTION
Before you submit your PR, make sure you check each of the following:

1. [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and signed the [Contributor License Agreement](./CLA.md).
2. [x] My code is clean and ready-to-PR, including being free of lint errors and dead code
3. [x] I have **tested** my change / code and am confident that it works
4. [x] I have filled in the template below completely and accurately
##### Changelog

- Updated references of kubeshark version 38.5 to 41.6
- Kubeshark config is required to be in the user's home directory, changed logic to create this file if it doesn't exist
- Updated `kubeshark tap` and `kubeshark clean` to follow new formats for helm vars and configuration
- Changed namespace from `kubeshark` to `default`
- Updated `defaultKubesharkConfig` to include the new output of `kubeshark config`
- Added the context (uuid for a worker) to the request to kubeshark hub

**Note**: Will add the following as a changelog to a wiki page:

># CHANGELOG
>
>## v41.6
>
>### Breaking Changes
>- Kubeshark updated from v38.5 to v41.6
>    - All namespaces tapped by default
>    - Deployment namespace is now default and not kubeshark
>    - Kubeshark config file is located at the user's home directory
>    - More information on Kubeshark changes can be found in the [Kubeshark wiki](https://github.com/kubeshark/kubeshark/wiki/CHANGELOG#412-2023-07-04)
>- Containers are published at ghcr.io/corshatech/kubeshark/corshavX.X (instead of /kubeshark-corshavX.X)


##### Testing

- Deployed cast using skaffold and checked that the collector was able to create records in postgres

##### Unit Tests

- Ran `collector_test.go` tests and ensured they passed

