### PR TITLE
CAST-204: Create matview of network traffic data relating src and dest IP addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Goland IDE config
+.idea/
+
 *.err
 
 vendor/

--- a/k8s/helm/cast/files/init.sql
+++ b/k8s/helm/cast/files/init.sql
@@ -85,4 +85,3 @@ CREATE VIEW matview_traffic_ips AS
         TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Real-Ip', ',')), '"[] ') AS ip_addr
     FROM traffic
     WHERE data->'request'->'headers'->>'X-Real-Ip' IS NOT NULL);
-SELECT * FROM matview_traffic_ips;

--- a/k8s/helm/cast/files/init.sql
+++ b/k8s/helm/cast/files/init.sql
@@ -75,7 +75,7 @@ CREATE VIEW matview_traffic_ips AS
     (SELECT
         id AS traffic_id,
         'src' AS direction,
-        TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Forwarded-For', ','))) AS ip_addr
+        TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Forwarded-For', ',')), '"[] ') AS ip_addr
     FROM traffic
     WHERE data->'request'->'headers'->>'X-Forwarded-For' IS NOT NULL)
     UNION

--- a/k8s/helm/cast/files/init.sql
+++ b/k8s/helm/cast/files/init.sql
@@ -80,9 +80,9 @@ CREATE VIEW matview_traffic_ips AS
     WHERE data->'request'->'headers'->>'X-Forwarded-For' IS NOT NULL)
     UNION
     (SELECT
-         id AS traffic_id,
-         'src' AS direction,
-         TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Real-IP', ',')), '"[] ') AS ip_addr
-     FROM traffic
-     WHERE data->'request'->'headers'->>'X-Real-IP' IS NOT NULL);
+        id AS traffic_id,
+        'src' AS direction,
+        TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Real-IP', ',')), '"[] ') AS ip_addr
+    FROM traffic
+    WHERE data->'request'->'headers'->>'X-Real-IP' IS NOT NULL);
 SELECT * FROM matview_traffic_ips;

--- a/k8s/helm/cast/files/init.sql
+++ b/k8s/helm/cast/files/init.sql
@@ -58,3 +58,17 @@ CREATE INDEX IF NOT EXISTS idx_traffic_data ON traffic USING gin (data);
 CREATE INDEX IF NOT EXISTS idx_auth_header ON traffic USING BTREE ((data->'request'->'headers'->>'Authorization'));
 CREATE INDEX IF NOT EXISTS idx_auth_header_src ON traffic USING BTREE ((data->'request'->'headers'->>'Authorization'), (data->'src'));
 CREATE INDEX IF NOT EXISTS idx_geo_ip_data_network ON geo_ip_data USING gist (network inet_ops);
+
+CREATE VIEW matview_traffic_ips AS
+    SELECT
+        id AS traffic_id,
+        'src' AS direction,
+        data->'src'->'ip' AS ip_addr
+    FROM traffic
+    UNION
+    SELECT
+        id AS traffic_id,
+        'dst' AS direction,
+        data->'dst'->'ip' AS ip_addr
+    FROM traffic;
+SELECT * FROM matview_traffic_ips;

--- a/k8s/helm/cast/files/init.sql
+++ b/k8s/helm/cast/files/init.sql
@@ -63,12 +63,19 @@ CREATE VIEW matview_traffic_ips AS
     SELECT
         id AS traffic_id,
         'src' AS direction,
-        data->'src'->'ip' AS ip_addr
+        data->'src'->>'ip' AS ip_addr
     FROM traffic
     UNION
     SELECT
         id AS traffic_id,
         'dst' AS direction,
-        data->'dst'->'ip' AS ip_addr
-    FROM traffic;
+        data->'dst'->>'ip' AS ip_addr
+    FROM traffic
+    UNION
+    (SELECT
+        id AS traffic_id,
+        'src' AS direction,
+        TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Forwarded-For', ','))) AS ip_addr
+    FROM traffic
+    WHERE data->'request'->'headers'->>'X-Forwarded-For' IS NOT NULL);
 SELECT * FROM matview_traffic_ips;

--- a/k8s/helm/cast/files/init.sql
+++ b/k8s/helm/cast/files/init.sql
@@ -82,7 +82,7 @@ CREATE VIEW matview_traffic_ips AS
     (SELECT
          id AS traffic_id,
          'src' AS direction,
-         data->'request'->'headers'->>'X-Real-IP' AS ip_addr
+         TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Real-IP', ',')), '"[] ') AS ip_addr
      FROM traffic
      WHERE data->'request'->'headers'->>'X-Real-IP' IS NOT NULL);
 SELECT * FROM matview_traffic_ips;

--- a/k8s/helm/cast/files/init.sql
+++ b/k8s/helm/cast/files/init.sql
@@ -82,7 +82,7 @@ CREATE VIEW matview_traffic_ips AS
     (SELECT
         id AS traffic_id,
         'src' AS direction,
-        TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Real-IP', ',')), '"[] ') AS ip_addr
+        TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Real-Ip', ',')), '"[] ') AS ip_addr
     FROM traffic
-    WHERE data->'request'->'headers'->>'X-Real-IP' IS NOT NULL);
+    WHERE data->'request'->'headers'->>'X-Real-Ip' IS NOT NULL);
 SELECT * FROM matview_traffic_ips;

--- a/k8s/helm/cast/files/init.sql
+++ b/k8s/helm/cast/files/init.sql
@@ -77,5 +77,12 @@ CREATE VIEW matview_traffic_ips AS
         'src' AS direction,
         TRIM(UNNEST(STRING_TO_ARRAY(data->'request'->'headers'->>'X-Forwarded-For', ','))) AS ip_addr
     FROM traffic
-    WHERE data->'request'->'headers'->>'X-Forwarded-For' IS NOT NULL);
+    WHERE data->'request'->'headers'->>'X-Forwarded-For' IS NOT NULL)
+    UNION
+    (SELECT
+         id AS traffic_id,
+         'src' AS direction,
+         data->'request'->'headers'->>'X-Real-IP' AS ip_addr
+     FROM traffic
+     WHERE data->'request'->'headers'->>'X-Real-IP' IS NOT NULL);
 SELECT * FROM matview_traffic_ips;

--- a/scripts/generate-pipeline-data.sh
+++ b/scripts/generate-pipeline-data.sh
@@ -85,9 +85,16 @@ echo -e "\ninserting reused-auth data\n"
 kubectl exec -n curl curl -i -- curl -s -w "\n" -H "Authorization: Bearer dummy-token1" "${svc}/headers?q=1"
 kubectl exec -n curl curl -i -- curl -s -w "\n" -H "Authorization: Bearer dummy-token2" "${svc}/headers?q=1"
 
-
 kubectl exec -n curl2 curl -i -- curl -s -w "\n" -H "Authorization: Bearer dummy-token1" "${svc}/headers?q=1"
 kubectl exec -n curl2 curl -i -- curl -s -w "\n" -H "Authorization: Bearer dummy-token2" "${svc}/headers?q=1"
+
+# Add test data using various headers with source and/or destination IP info
+echo -e "\ninserting traffic data with X-Forwarded-For and X-Real-Ip headers\n"
+kubectl exec -n curl curl -i -- curl -s -w "\n" -H "Authorization: Bearer cool-token1" -H "X-Forwarded-For: 0.0.0.0" "${svc}/headers?q=1"
+kubectl exec -n curl curl -i -- curl -s -w "\n" -H "Authorization: Bearer cool-token2" -H "X-Forwarded-For: 1.1.1.1,2.2.2.2" "${svc}/headers?q=1"
+kubectl exec -n curl curl -i -- curl -s -w "\n" -H "Authorization: Bearer cool-token3" -H "X-Forwarded-For: [3.3.3.3, 4.4.4.4]" "${svc}/headers?q=1"
+kubectl exec -n curl curl -i -- curl -s -w "\n" -H "Authorization: Bearer cool-token4" -H "X-Real-Ip: 5.5.5.5" "${svc}/headers?q=1"
+kubectl exec -n curl curl -i -- curl -s -w "\n" -H "Authorization: Bearer cool-token5" -H "X-Real-Ip: 6.6.6.6,7.7.7.7" "${svc}/headers?q=1"
 
 ########
 # SLOWLY INSERTED DATA BLOCK
@@ -101,7 +108,6 @@ if [ "$CAST_FAST_DATA_ONLY" = "true" ]; then
     echo "Done: Skipping long-running test data"
     exit 0;
 fi
-
 
 # 5 Request Too Slow
 echo -e "\ninserting request-too-slow data\n"


### PR DESCRIPTION
1. [X] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and signed the [Contributor License Agreement](./CLA.md).
2. [X] My code is clean and ready-to-PR, including being free of lint errors and dead code
3. [X] I have **tested** my change / code and am confident that it works
4. [X] I have filled in the template below completely and accurately

##### Changelog

**`.gitignore`**:
- Add line for Goland IDE configuration.

**`k8s/helm/cast/files/init.sql`**:
- Define materialized view called `matview_traffic_ips` that extracts the source and destination IP addresses from the traffic data JSON, specifically:
  - source address and destination address from the traffic's IPv4 packet header, as described here: https://en.wikipedia.org/wiki/Internet_Protocol_version_4#Header
  - source address(es) from the traffic's `X-Forwarded-For` HTTP header, as described here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For. Note that we are ignoring potential spoofing of this header for now.
  - source address(es) from the traffic's `X-Real-Ip` HTTP header, as described here: https://docs.oracle.com/en-us/iaas/Content/Balance/Reference/httpheaders.htm#HTTP_X_Headers__XRealIP. Note that we are ignoring potential spoofing of this header for now. Also note that we can handle this header potentially containing a list of IP addresses because `X-Real-Ip` isn’t actually specified by any RFC, but instead is an informal ad-hoc implementation detail of several proxy server implementations (like Nginx).

The materialized view in the database assumes that the traffic data has already been appropriately normalized to be one case and one key (repeated headers are combined) by CAST's data-handling pipeline.

**`scripts/generate-pipeline-data.sh`**:
- Simulate traffic with various `X-Forwarded-For` and `X-Real-Ip` HTTP header values to ensure they are captured correctly in the materialized view in the database.

##### Testing

1. Set up your local development environment following these instructions: https://github.com/corshatech/cast/blob/main/DEVELOPING.md.
2. Make sure that the Docker Desktop application is running with Kubernetes enabled.
3. Make sure that the OpenLens application is running, and you are in the `docker-desktop` cluster.
4. Run this command in the base directory of your CAST repository: `KUBESHARK_HELM_CHART_PATH="/Users/katie/Downloads/kubeshark-41.6.tgz" skaffold dev --platform=linux/amd64 --profile headless --port-forward --kube-context docker-desktop`
5. Go to Workloads > Pods, and click on the pod for the PostgreSQL DB: `cast-postgresql-0`
6. Scroll down to the Environment section, find where it says `POSTGRES_DB`, and take note of the database name there (should be “cast”). Then find where it says `POSTGRES_USER`, and take note of the username there (should be “cast”). Then find where it says `POSTGRES_PASSWORD` (NOT `POSTGRES_POSTGRES_PASSWORD`), click on the little eyeball, and copy the password.
7. Still through OpenLens, open up a terminal in the `cast-postgresql-0` pod and start psql:
```
psql -U <username> -h localhost <database>
```
AKA: 
```
psql -U cast -h localhost cast
```
8. When you are prompted for the password, paste it from your clipboard and press enter. You can then use `psql`!
9. Type `\d` and press enter to list all the tables. You should see the new materialized view there!

<img width="1009" alt="Screenshot 2023-09-14 at 4 29 00 PM" src="https://github.com/corshatech/cast/assets/139792177/bf648fe9-a5ce-4b64-acd5-2ab61b3cb43e">

11. Select all data from the materialized view to double check that the values from the data generation script have been added to the DB and queried as expected.

<img width="518" alt="Screenshot 2023-09-14 at 4 31 13 PM" src="https://github.com/corshatech/cast/assets/139792177/9d76f782-8c31-4582-aa31-0622286b65c7">

<img width="620" alt="Screenshot 2023-09-20 at 9 26 21 AM" src="https://github.com/corshatech/cast/assets/139792177/e2a9da17-3fdc-480b-9a34-f97c49d7fb3b">

Note in the screenshots that the test data from the `X-Forwarded-For` header shows up correctly. However, the `X-Real-Ip` header data is missing. Since I've had this data correctly show up in the past, I think that the matview simply needs to be refreshed. However, I don't seem to have enough permission to refresh the mat view manually.

##### Unit Tests

None.