### PR TITLE
CAST-253: Support basic auth for reading Jenkins user info

### DIFF
--- a/plugins/jenkins/main.go
+++ b/plugins/jenkins/main.go
@@ -29,9 +29,13 @@ import (
 )
 
 const (
-	// For now, since authentication has not been implemented for hitting the Jenkins instance,
-	// this URL must correspond with a public Jenkins instance.
+	// For now, since more advanced authentication has not been implemented for hitting the Jenkins instance,
+	// this URL must correspond with either a public Jenkins instance or a Jenkins instance supporting
+	// basic authentication.
 	jenkinsTLDEnv = "JENKINS_TLD"
+
+	usernameEnv = "JENKINS_USERNAME"
+	passwordEnv = "JENKINS_PASSWORD"
 
 	requestTimeout = 2 * time.Minute
 )
@@ -99,7 +103,7 @@ func main() {
 
 	req.Header.Set("Accept", "application/json")
 
-	// TODO(STR-5415): Set up authentication on the request to hit a non-public Jenkins instance
+	setBasicAuth(req)
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -122,4 +126,18 @@ func main() {
 
 	log.WithField("resultsLength", len(data.Users)).Info("Scan completed. Skipping writing results to CAST DB...")
 	log.Info("Done.")
+}
+
+func setBasicAuth(req *http.Request) {
+	username := os.Getenv(usernameEnv)
+	if username == "" {
+		log.Fatalf("Required environment variable %s is not set!", usernameEnv)
+	}
+
+	password := os.Getenv(passwordEnv)
+	if password == "" {
+		log.Fatalf("Required environment variable %s is not set!", passwordEnv)
+	}
+
+	req.SetBasicAuth(username, password)
 }

--- a/plugins/jenkins/main.go
+++ b/plugins/jenkins/main.go
@@ -131,12 +131,12 @@ func main() {
 func setBasicAuth(req *http.Request) {
 	username := os.Getenv(usernameEnv)
 	if username == "" {
-		log.Fatalf("Required environment variable %s is not set!", usernameEnv)
+		return
 	}
 
 	password := os.Getenv(passwordEnv)
 	if password == "" {
-		log.Fatalf("Required environment variable %s is not set!", passwordEnv)
+		return
 	}
 
 	req.SetBasicAuth(username, password)


### PR DESCRIPTION

1. [X] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and signed the [Contributor License Agreement](./CLA.md).
2. [X] My code is clean and ready-to-PR, including being free of lint errors and dead code
3. [X] I have **tested** my change / code and am confident that it works
4. [X] I have filled in the template below completely and accurately

##### Changelog

**`plugins/jenkins/main.go`**:
- Added optional support for basic authentication on the request to read user info from the specified Jenkins instance. If the Jenkins username or password environment values are missing, still attempt to read the user issue without authenticating.

##### Testing

I spun up a local Jenkins instance that accepts just a username and a password to authenticate (no 2FA or anything more than just basic auth). I then ran the program without the necessary username and password environment values to confirm that it failed:

```
JENKINS_TLD="<jenkins_instance_tld>" go run ./plugins/jenkins/main.go
```
```
INFO[0000] Successfully built URL to fetch Jenkins user data  requestURL="<jenkins_instance_tld>/asynchPeople/api/json?tree=users[lastChange,project[fullName,url],user[id,fullName,absoluteURL,property[_class,address]{,15}]]"
INFO[0000] response body: <html><head><meta http-equiv='refresh' content='1;url=/login?from=%2FasynchPeople%2Fapi%2Fjson%3Ftree%3Dusers%5BlastChange%2Cproject%5BfullName%2Curl%5D%2Cuser%5Bid%2CfullName%2CabsoluteURL%2Cproperty%5B_class%2Caddress%5D%7B%2C15%7D%5D%5D'/><script>window.location.replace('/login?from=%2FasynchPeople%2Fapi%2Fjson%3Ftree%3Dusers%5BlastChange%2Cproject%5BfullName%2Curl%5D%2Cuser%5Bid%2CfullName%2CabsoluteURL%2Cproperty%5B_class%2Caddress%5D%7B%2C15%7D%5D%5D');</script></head><body style='background-color:white; color:white;'>


Authentication required
<!--
-->

</body></html>                                                                                                                                                                                                                                                                                                             
FATA[0000] could not unmarshal user data                 error="invalid character '<' looking for beginning of value"
exit status 1
```

I then ran the program again but this time provided the necessary username and password for the Jenkins instance:

```
JENKINS_TLD="<jenkins_instance_tld>" JENKINS_USERNAME="admin" JENKINS_PASSWORD="<password>" go run ./plugins/jenkins/main.go
```
```
INFO[0000] Successfully built URL to fetch Jenkins user data  requestURL="<jenkins_instance_tld>/asynchPeople/api/json?tree=users[lastChange,project[fullName,url],user[id,fullName,absoluteURL,property[_class,address]{,15}]]"
INFO[0000] response body: {"_class":"hudson.model.View$AsynchPeople$People","users":[{"lastChange":null,"project":null,"user":{"fullName":"Jenkins Admin","id":"admin","property":[{"_class":"jenkins.security.ApiTokenProperty"},{"_class":"io.jenkins.blueocean.autofavorite.user.FavoritingUserProperty"},{"_class":"com.cloudbees.plugins.credentials.UserCredentialsProvider$UserCredentialsProperty"},{"_class":"hudson.tasks.Mailer$UserProperty","address":null},{"_class":"hudson.plugins.favorite.user.FavoriteUserProperty"},{"_class":"hudson.model.MyViewsProperty"},{"_class":"org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty"},{"_class":"hudson.model.PaneStatusProperties"},{"_class":"jenkins.security.seed.UserSeedProperty"},{"_class":"hudson.search.UserSearchProperty"},{"_class":"jenkins.plugins.slack.user.SlackUserProperty"},{"_class":"hudson.model.TimeZoneProperty"},{"_class":"jenkins.model.experimentalflags.UserExperimentalFlagsProperty"},{"_class":"hudson.security.HudsonPrivateSecurityRealm$Details"}]}}]} 
INFO[0000] Scan completed. Skipping writing results to CAST DB...  resultsLength=1
INFO[0000] Done.                                     
```

##### Unit Tests

N/A
